### PR TITLE
Convert component slices to maps

### DIFF
--- a/pkg/landscaper/component.go
+++ b/pkg/landscaper/component.go
@@ -17,6 +17,8 @@ type Component struct {
 	SecretValues  SecretValues  `json:"-"`
 }
 
+type Components map[string]*Component
+
 // NewComponent creates a Component and adds Name to the configuration
 func NewComponent(name string, release *Release, cfg Configuration, secrets Secrets) *Component {
 	cmp := &Component{
@@ -56,7 +58,7 @@ func (c *Component) Equals(other *Component) bool {
 }
 
 // validateComponents validates the individual components as well as duplicate names in the total collection
-func validateComponents(cs map[string]*Component) error {
+func validateComponents(cs Components) error {
 	// are the individual components okay?
 	for _, c := range cs {
 		if err := c.Validate(); err != nil {
@@ -65,7 +67,7 @@ func validateComponents(cs map[string]*Component) error {
 	}
 
 	// is the collection as a whole okay: no dup names?
-	cMap := make(map[string]*Component)
+	cMap := make(Components)
 
 	for _, c := range cs {
 		if _, ok := cMap[c.Name]; ok {

--- a/pkg/landscaper/component.go
+++ b/pkg/landscaper/component.go
@@ -17,6 +17,7 @@ type Component struct {
 	SecretValues  SecretValues  `json:"-"`
 }
 
+// Components is a collection of uniquely named Component objects
 type Components map[string]*Component
 
 // NewComponent creates a Component and adds Name to the configuration
@@ -64,16 +65,6 @@ func validateComponents(cs Components) error {
 		if err := c.Validate(); err != nil {
 			return err
 		}
-	}
-
-	// is the collection as a whole okay: no dup names?
-	cMap := Components{}
-
-	for _, c := range cs {
-		if _, ok := cMap[c.Name]; ok {
-			return fmt.Errorf("duplicate component name `%s`", c.Name)
-		}
-		cMap[c.Name] = c
 	}
 
 	return nil

--- a/pkg/landscaper/component.go
+++ b/pkg/landscaper/component.go
@@ -67,7 +67,7 @@ func validateComponents(cs Components) error {
 	}
 
 	// is the collection as a whole okay: no dup names?
-	cMap := make(Components)
+	cMap := Components{}
 
 	for _, c := range cs {
 		if _, ok := cMap[c.Name]; ok {

--- a/pkg/landscaper/component.go
+++ b/pkg/landscaper/component.go
@@ -56,7 +56,7 @@ func (c *Component) Equals(other *Component) bool {
 }
 
 // validateComponents validates the individual components as well as duplicate names in the total collection
-func validateComponents(cs []*Component) error {
+func validateComponents(cs map[string]*Component) error {
 	// are the individual components okay?
 	for _, c := range cs {
 		if err := c.Validate(); err != nil {

--- a/pkg/landscaper/component_provider.go
+++ b/pkg/landscaper/component_provider.go
@@ -27,8 +27,8 @@ var (
 
 // ComponentProvider can be used to interact with components locally, as well as on the cluster
 type ComponentProvider interface {
-	Current() (map[string]*Component, error)
-	Desired() (map[string]*Component, error)
+	Current() (Components, error)
+	Desired() (Components, error)
 }
 
 type componentProvider struct {
@@ -45,8 +45,8 @@ func NewComponentProvider(env *Environment, secretsProvider SecretsProvider) Com
 }
 
 // Current returns all Components in the cluster
-func (cp *componentProvider) Current() (map[string]*Component, error) {
-	components := make(map[string]*Component)
+func (cp *componentProvider) Current() (Components, error) {
+	components := make(Components)
 
 	logrus.Info("Obtain current state Helm Releases (Components) from Tiller")
 
@@ -87,8 +87,8 @@ func (cp *componentProvider) Current() (map[string]*Component, error) {
 }
 
 // Desired returns all desired components according to their descriptions
-func (cp *componentProvider) Desired() (map[string]*Component, error) {
-	components := make(map[string]*Component)
+func (cp *componentProvider) Desired() (Components, error) {
+	components := make(Components)
 
 	logrus.WithFields(logrus.Fields{"directory": cp.env.LandscapeDir}).Info("Obtain desired state from directory")
 

--- a/pkg/landscaper/component_provider.go
+++ b/pkg/landscaper/component_provider.go
@@ -27,8 +27,8 @@ var (
 
 // ComponentProvider can be used to interact with components locally, as well as on the cluster
 type ComponentProvider interface {
-	Current() ([]*Component, error)
-	Desired() ([]*Component, error)
+	Current() (map[string]*Component, error)
+	Desired() (map[string]*Component, error)
 }
 
 type componentProvider struct {
@@ -45,8 +45,8 @@ func NewComponentProvider(env *Environment, secretsProvider SecretsProvider) Com
 }
 
 // Current returns all Components in the cluster
-func (cp *componentProvider) Current() ([]*Component, error) {
-	components := []*Component{}
+func (cp *componentProvider) Current() (map[string]*Component, error) {
+	components := make(map[string]*Component)
 
 	logrus.Info("Obtain current state Helm Releases (Components) from Tiller")
 
@@ -78,7 +78,7 @@ func (cp *componentProvider) Current() ([]*Component, error) {
 		}
 		sort.Strings(cmp.Secrets) // enforce a consistent ordering for proper diffing / deepEqualing
 
-		components = append(components, cmp)
+		components[cmp.Name] = cmp
 	}
 
 	logrus.WithFields(logrus.Fields{"totalReleases": len(helmReleases), "landscapedComponents": len(components)}).Info("Retrieved Releases (Components)")
@@ -87,8 +87,8 @@ func (cp *componentProvider) Current() ([]*Component, error) {
 }
 
 // Desired returns all desired components according to their descriptions
-func (cp *componentProvider) Desired() ([]*Component, error) {
-	components := []*Component{}
+func (cp *componentProvider) Desired() (map[string]*Component, error) {
+	components := make(map[string]*Component)
 
 	logrus.WithFields(logrus.Fields{"directory": cp.env.LandscapeDir}).Info("Obtain desired state from directory")
 
@@ -130,7 +130,7 @@ func (cp *componentProvider) Desired() ([]*Component, error) {
 
 		logrus.Debugf("desired %#v", *cmp)
 
-		components = append(components, cmp)
+		components[cmp.Name] = cmp
 	}
 
 	if err := validateComponents(components); err != nil {

--- a/pkg/landscaper/component_provider.go
+++ b/pkg/landscaper/component_provider.go
@@ -125,7 +125,12 @@ func (cp *componentProvider) Desired() (Components, error) {
 		}
 
 		if err := cmp.Validate(); err != nil {
-			return nil, fmt.Errorf("failed to validate `%s`: %s", filename, err)
+			return components, fmt.Errorf("failed to validate `%s`: %s", filename, err)
+		}
+
+		// make sure there are no duplicate names
+		if _, ok := components[cmp.Name]; ok {
+			return components, fmt.Errorf("duplicate component name `%s`", cmp.Name)
 		}
 
 		logrus.Debugf("desired %#v", *cmp)
@@ -134,7 +139,7 @@ func (cp *componentProvider) Desired() (Components, error) {
 	}
 
 	if err := validateComponents(components); err != nil {
-		return nil, err
+		return components, err
 	}
 
 	logrus.WithFields(logrus.Fields{"directory": cp.env.LandscapeDir, "components": len(components)}).Debug("Desired state has been read")

--- a/pkg/landscaper/component_provider.go
+++ b/pkg/landscaper/component_provider.go
@@ -46,7 +46,7 @@ func NewComponentProvider(env *Environment, secretsProvider SecretsProvider) Com
 
 // Current returns all Components in the cluster
 func (cp *componentProvider) Current() (Components, error) {
-	components := make(Components)
+	components := Components{}
 
 	logrus.Info("Obtain current state Helm Releases (Components) from Tiller")
 
@@ -88,7 +88,7 @@ func (cp *componentProvider) Current() (Components, error) {
 
 // Desired returns all desired components according to their descriptions
 func (cp *componentProvider) Desired() (Components, error) {
-	components := make(Components)
+	components := Components{}
 
 	logrus.WithFields(logrus.Fields{"directory": cp.env.LandscapeDir}).Info("Obtain desired state from directory")
 

--- a/pkg/landscaper/executor.go
+++ b/pkg/landscaper/executor.go
@@ -14,7 +14,7 @@ import (
 
 // Executor is responsible for applying a desired landscape to the actual landscape
 type Executor interface {
-	Apply(map[string]*Component, map[string]*Component) error
+	Apply(Components, Components) error
 
 	CreateComponent(*Component) error
 	UpdateComponent(*Component) error
@@ -35,7 +35,7 @@ func NewExecutor(env *Environment, secretsProvider SecretsProvider) Executor {
 }
 
 // Apply transforms the current state into the desired state
-func (e *executor) Apply(desired, current map[string]*Component) error {
+func (e *executor) Apply(desired, current Components) error {
 	create, update, delete := diff(desired, current)
 
 	// some to-be-updated components need a delete + create instead
@@ -225,10 +225,10 @@ func (e *executor) DeleteComponent(cmp *Component) error {
 }
 
 // diff takes desired and current components, and returns the components to create, update and delete to get from current to desired
-func diff(desired, current map[string]*Component) (create, update, delete map[string]*Component) {
-	create = make(map[string]*Component)
-	update = make(map[string]*Component)
-	delete = make(map[string]*Component)
+func diff(desired, current Components) (create, update, delete Components) {
+	create = make(Components)
+	update = make(Components)
+	delete = make(Components)
 
 	for name, desiredCmp := range desired {
 		if currentCmp, ok := current[name]; ok {
@@ -280,7 +280,7 @@ func componentDiffText(current, desired *Component) (string, error) {
 }
 
 // logDifferences logs the Create, Update and Delete w.r.t. current to logf
-func logDifferences(currentMap, creates, updates, deletes map[string]*Component, logf func(format string, args ...interface{})) error {
+func logDifferences(currentMap, creates, updates, deletes Components, logf func(format string, args ...interface{})) error {
 	log := func(action string, current, desired *Component) error {
 		diff, err := componentDiffText(current, desired)
 		if err != nil {
@@ -317,8 +317,8 @@ func logDifferences(currentMap, creates, updates, deletes map[string]*Component,
 }
 
 // integrateForcedUpdates removes forceUpdate from update and inserts it into delete + create
-func integrateForcedUpdates(current, create, update, delete map[string]*Component, forceUpdate map[string]bool) (map[string]*Component, map[string]*Component, map[string]*Component) {
-	fixUpdate := make(map[string]*Component)
+func integrateForcedUpdates(current, create, update, delete Components, forceUpdate map[string]bool) (Components, Components, Components) {
+	fixUpdate := make(Components)
 	for _, cmp := range update {
 		if forceUpdate[cmp.Name] {
 			for _, currentCmp := range current {

--- a/pkg/landscaper/executor.go
+++ b/pkg/landscaper/executor.go
@@ -226,9 +226,9 @@ func (e *executor) DeleteComponent(cmp *Component) error {
 
 // diff takes desired and current components, and returns the components to create, update and delete to get from current to desired
 func diff(desired, current Components) (create, update, delete Components) {
-	create = make(Components)
-	update = make(Components)
-	delete = make(Components)
+	create = Components{}
+	update = Components{}
+	delete = Components{}
 
 	for name, desiredCmp := range desired {
 		if currentCmp, ok := current[name]; ok {
@@ -318,7 +318,7 @@ func logDifferences(currentMap, creates, updates, deletes Components, logf func(
 
 // integrateForcedUpdates removes forceUpdate from update and inserts it into delete + create
 func integrateForcedUpdates(current, create, update, delete Components, forceUpdate map[string]bool) (Components, Components, Components) {
-	fixUpdate := make(Components)
+	fixUpdate := Components{}
 	for _, cmp := range update {
 		if forceUpdate[cmp.Name] {
 			for _, currentCmp := range current {

--- a/pkg/landscaper/executor_test.go
+++ b/pkg/landscaper/executor_test.go
@@ -12,13 +12,13 @@ import (
 )
 
 func TestExecutorDiff(t *testing.T) {
-	current := map[string]*Component{
+	current := Components{
 		"cmpA": &Component{Name: "cmpA"},
 		"cmpB": &Component{Name: "cmpB", Release: &Release{Chart: "chart1"}},
 		"cmpC": &Component{Name: "cmpC"},
 	}
 
-	desired := map[string]*Component{
+	desired := Components{
 		"cmpD": &Component{Name: "cmpD"},
 		"cmpB": &Component{Name: "cmpB", Release: &Release{Chart: "chart2"}},
 		"cmpC": &Component{Name: "cmpC"},
@@ -26,9 +26,9 @@ func TestExecutorDiff(t *testing.T) {
 
 	actualC, actualU, actualD := diff(desired, current)
 
-	expectedC := map[string]*Component{"cmpD": &Component{Name: "cmpD"}}
-	expectedU := map[string]*Component{"cmpB": &Component{Name: "cmpB", Release: &Release{Chart: "chart2"}}}
-	expectedD := map[string]*Component{"cmpA": &Component{Name: "cmpA"}}
+	expectedC := Components{"cmpD": &Component{Name: "cmpD"}}
+	expectedU := Components{"cmpB": &Component{Name: "cmpB", Release: &Release{Chart: "chart2"}}}
+	expectedD := Components{"cmpA": &Component{Name: "cmpA"}}
 
 	assert.Equal(t, expectedC, actualC)
 	assert.Equal(t, expectedU, actualU)
@@ -152,19 +152,19 @@ func TestIntegrateForcedUpdates(t *testing.T) {
 	d.Name = "D"
 	f.Name = "F"
 
-	current := map[string]*Component{u.Name: u, f.Name: f, d.Name: d}
+	current := Components{u.Name: u, f.Name: f, d.Name: d}
 
-	create := map[string]*Component{c.Name: c}
-	update := map[string]*Component{u.Name: u, f.Name: f}
-	delete := map[string]*Component{d.Name: d}
+	create := Components{c.Name: c}
+	update := Components{u.Name: u, f.Name: f}
+	delete := Components{d.Name: d}
 
 	needForcedUpdate := map[string]bool{"F": true}
 
 	create, update, delete = integrateForcedUpdates(current, create, update, delete, needForcedUpdate)
 
-	require.Equal(t, map[string]*Component{c.Name: c, f.Name: f}, create)
-	require.Equal(t, map[string]*Component{u.Name: u}, update)
-	require.Equal(t, map[string]*Component{d.Name: d, f.Name: f}, delete)
+	require.Equal(t, Components{c.Name: c, f.Name: f}, create)
+	require.Equal(t, Components{u.Name: u}, update)
+	require.Equal(t, Components{d.Name: d, f.Name: f}, delete)
 }
 
 func newTestComponent() *Component {

--- a/pkg/landscaper/executor_test.go
+++ b/pkg/landscaper/executor_test.go
@@ -12,23 +12,23 @@ import (
 )
 
 func TestExecutorDiff(t *testing.T) {
-	current := []*Component{
-		&Component{Name: "cmpA"},
-		&Component{Name: "cmpB", Release: &Release{Chart: "chart1"}},
-		&Component{Name: "cmpC"},
+	current := map[string]*Component{
+		"cmpA": &Component{Name: "cmpA"},
+		"cmpB": &Component{Name: "cmpB", Release: &Release{Chart: "chart1"}},
+		"cmpC": &Component{Name: "cmpC"},
 	}
 
-	desired := []*Component{
-		&Component{Name: "cmpD"},
-		&Component{Name: "cmpB", Release: &Release{Chart: "chart2"}},
-		&Component{Name: "cmpC"},
+	desired := map[string]*Component{
+		"cmpD": &Component{Name: "cmpD"},
+		"cmpB": &Component{Name: "cmpB", Release: &Release{Chart: "chart2"}},
+		"cmpC": &Component{Name: "cmpC"},
 	}
 
 	actualC, actualU, actualD := diff(desired, current)
 
-	expectedC := []*Component{&Component{Name: "cmpD"}}
-	expectedU := []*Component{&Component{Name: "cmpB", Release: &Release{Chart: "chart2"}}}
-	expectedD := []*Component{&Component{Name: "cmpA"}}
+	expectedC := map[string]*Component{"cmpD": &Component{Name: "cmpD"}}
+	expectedU := map[string]*Component{"cmpB": &Component{Name: "cmpB", Release: &Release{Chart: "chart2"}}}
+	expectedD := map[string]*Component{"cmpA": &Component{Name: "cmpA"}}
 
 	assert.Equal(t, expectedC, actualC)
 	assert.Equal(t, expectedU, actualU)
@@ -152,19 +152,19 @@ func TestIntegrateForcedUpdates(t *testing.T) {
 	d.Name = "D"
 	f.Name = "F"
 
-	current := []*Component{u, f, d}
+	current := map[string]*Component{u.Name: u, f.Name: f, d.Name: d}
 
-	create := []*Component{c}
-	update := []*Component{u, f}
-	delete := []*Component{d}
+	create := map[string]*Component{c.Name: c}
+	update := map[string]*Component{u.Name: u, f.Name: f}
+	delete := map[string]*Component{d.Name: d}
 
 	needForcedUpdate := map[string]bool{"F": true}
 
 	create, update, delete = integrateForcedUpdates(current, create, update, delete, needForcedUpdate)
 
-	require.Equal(t, []*Component{c, f}, create)
-	require.Equal(t, []*Component{u}, update)
-	require.Equal(t, []*Component{d, f}, delete)
+	require.Equal(t, map[string]*Component{c.Name: c, f.Name: f}, create)
+	require.Equal(t, map[string]*Component{u.Name: u}, update)
+	require.Equal(t, map[string]*Component{d.Name: d, f.Name: f}, delete)
 }
 
 func newTestComponent() *Component {


### PR DESCRIPTION
an attempt to solve https://github.com/Eneco/landscaper/issues/15

changes:
* change `[]*Component`to `map[string]*Component`
* alias `Components` to `map[string]*Component`
* initialize `Components` via `Components{}` instead of `make(Components)` (why expose that `Components` is actually a map 😄 )
* remove now obsolete on-the-fly slice-to-map conversions