### PR TITLE
Update Helm client

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,8 +5,8 @@ RUN echo '@edge https://nl.alpinelinux.org/alpine/edge/main' >> /etc/apk/reposit
     apk upgrade --update && \
     apk add bash curl ca-certificates
 
-ENV HELM_VERSION="v2.0.0" \
-    KUBE_VERSION="1.4.6" \
+ENV HELM_VERSION="v2.2.0" \
+    KUBE_VERSION="1.5.3" \
     KUBE_FOLDER="/root/.kube"
 
 RUN curl -s https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz | tar -xz -C /tmp && mv /tmp/linux-amd64/helm /usr/bin


### PR DESCRIPTION
This updates the Helm client to the latest 2.2.x version.

It also updates the Kubernetes env var to the latest 1.5 release