### PR TITLE
Provide a way to run landscaper as a controller

### DIFF
--- a/pkg/landscaper/environment.go
+++ b/pkg/landscaper/environment.go
@@ -3,6 +3,7 @@ package landscaper
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/Sirupsen/logrus"
 	"k8s.io/helm/pkg/helm"
@@ -30,6 +31,8 @@ type Environment struct {
 	Verbose           bool
 	NoCronUpdate      bool // NoCronUpdate replaces a CronJob update with a create+delete; k8s #35149 work around
 	Context           string
+	Loop              bool
+	LoopInterval      time.Duration
 
 	helmClient helm.Interface
 	kubeClient internalversion.CoreInterface


### PR DESCRIPTION
This allows running `landscaper` as a controller in the cluster that can constantly watch a source of landscaped files and apply them to the cluster.

It provides a boolean `--loop` flag to the `apply` command which will run the usual apply code in a loop. Delay between the iterations can be controlled with `--loop-interval`, see below for an example. The default for `--loop` is false so there's no change to the current behaviour without that flag.

An example manifest file how this can be setup with a Git repository syncer as a sidecar on a private repository is shown below. It works as expected but there's one gotcha: the very first landscaper run after pod creation will remove everything as the Git repo hasn't been synced yet. But that can be fixed in another PR.

```yaml
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  name: landscaper
  namespace: landscaper
  labels:
    app: landscaper
spec:
  template:
    metadata:
      labels:
        app: landscaper
    spec:
      containers:
      - name: landscaper
        image: quay.io/linki/landscaper:1.0.0-7-gbaf94f3
        command:
        - /usr/bin/landscaper
        args:
        - apply
        - --dir=/git/some-repo
        - --namespace=landscaper-test
        - --loop
        - --loop-interval=1m
        - --verbose
        volumeMounts:
        - mountPath: /git
          name: landscaper
          readOnly: true
      - name: git-sync
        image: gcr.io/google-containers/git-sync:v2.0.4
        args:
        - --branch=master
        - --repo=https://github.com/you/some-repo.git
        - --root=/git
        - --dest=some-repo
        - --wait=60
        - --username=you
        - --password=yourtoken
        securityContext:
          runAsUser: 0
        volumeMounts:
        - mountPath: /git
          name: landscaper
      volumes:
      - name: landscaper
        emptyDir:
          medium: Memory
```