### PR TITLE
simplify Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,21 +1,17 @@
-FROM alpine
+FROM alpine:3.5
 
-RUN echo '@edge https://nl.alpinelinux.org/alpine/edge/main' >> /etc/apk/repositories && \
-    echo '@community https://nl.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories && \
-    apk upgrade --update && \
-    apk add bash curl ca-certificates
+ENV HELM_VERSION v2.2.0
 
-ENV HELM_VERSION="v2.2.0" \
-    KUBE_VERSION="1.5.3" \
-    KUBE_FOLDER="/root/.kube"
+RUN apk add --no-cache \
+  ca-certificates \
+  curl
 
-RUN curl -s https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz | tar -xz -C /tmp && mv /tmp/linux-amd64/helm /usr/bin
+RUN curl -s https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz | \
+  tar -xz -C /tmp && mv /tmp/linux-amd64/helm /usr/bin
 
-RUN helm init --client-only && \
-    mkdir -v -p /root/.kube
+RUN helm init --client-only
 
 COPY landscaper bootstrap /usr/bin/
 
-CMD bash
-
-WORKDIR /root
+CMD ["landscaper"]
+ENTRYPOINT ["/usr/bin/bootstrap"]

--- a/docker/bootstrap
+++ b/docker/bootstrap
@@ -1,24 +1,5 @@
-#/bin/bash -x
-#fills in /root/.kube/config from environment; issues a helm repo update
-cat >/root/.kube/config <<EOF
-apiVersion: v1
-clusters:
-- cluster:
-    insecure-skip-tls-verify: true
-    server: ${K8S_MASTER_URL}
-  name: engd
-contexts:
-- context:
-    cluster: engd
-    user: ${K8S_USERNAME}
-  name: engd
-current-context: engd
-kind: Config
-preferences: {}
-users:
-- name: ${K8S_USERNAME}
-  user:
-    token: ${K8S_PASSWORD}
-EOF
+#!/bin/sh -x
 
 helm repo update
+
+exec "$@"


### PR DESCRIPTION
An attempt to simplify the Dockerfile a little. I don't understand why you needed the kubeconfig and version there, for me it works fine without from inside a GKE cluster. From other environments I would probably just spin up a `kubectl proxy` if helm's tunnel doesn't suffice.

Also fixes https://github.com/Eneco/landscaper/issues/31