### PR TITLE
feat: use HELM_HOST if defined

### DIFF
--- a/pkg/landscaper/environment.go
+++ b/pkg/landscaper/environment.go
@@ -2,6 +2,7 @@ package landscaper
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -105,6 +106,12 @@ func (e *Environment) ReleaseName(componentName string) string {
 
 // setupConnection creates and returns tiller port forwarding tunnel
 func setupConnection(context string) (string, error) {
+	helmHost, helmHostExists := os.LookupEnv("HELM_HOST")
+	if helmHostExists {
+		logrus.WithFields(logrus.Fields{"helmHost": helmHost}).Debug("Using tiller address from HELM_HOST")
+		return helmHost, nil
+	}
+
 	logrus.WithFields(logrus.Fields{"tillerNamespace": tillerNamespace}).Debug("Create tiller tunnel")
 	tunnel, err := newTillerPortForwarder(tillerNamespace, context)
 	if err != nil {


### PR DESCRIPTION
Helm uses the HELM_HOST environment variable for the tiller address if it exists instead of looking for a pod in Kubernetes (it can also be specified with --host)

This makes landscaper look for the HELM_HOST environment variable and use it directly if it's set instead of creating the tunnel.