### PR TITLE
WIP: Allow configuring namespaces

### DIFF
--- a/pkg/landscaper/component.go
+++ b/pkg/landscaper/component.go
@@ -11,6 +11,7 @@ import (
 // Component contains information about the release, configuration and secrets of a component
 type Component struct {
 	Name          string        `json:"name" validate:"nonzero,max=51"`
+	Namespace     string        `json:"namespace"`
 	Release       *Release      `json:"release" validate:"nonzero"`
 	Configuration Configuration `json:"configuration"`
 	Secrets       Secrets       `json:"secrets"`
@@ -21,13 +22,14 @@ type Component struct {
 type Components map[string]*Component
 
 // NewComponent creates a Component and adds Name to the configuration
-func NewComponent(name string, release *Release, cfg Configuration, secrets Secrets) *Component {
+func NewComponent(name string, namespace string, release *Release, cfg Configuration, secrets Secrets) *Component {
 	cmp := &Component{
 		Name:          name,
 		Release:       release,
 		Configuration: cfg,
 		Secrets:       secrets,
 		SecretValues:  SecretValues{},
+		Namespace:     namespace,
 	}
 
 	if cmp.Configuration == nil {

--- a/pkg/landscaper/component_provider.go
+++ b/pkg/landscaper/component_provider.go
@@ -166,7 +166,7 @@ func newComponentFromYAML(content []byte) (*Component, error) {
 		return nil, err
 	}
 
-	return NewComponent(cmp.Name, cmp.Release, cmp.Configuration, cmp.Secrets), nil
+	return NewComponent(cmp.Name, cmp.Namespace, cmp.Release, cmp.Configuration, cmp.Secrets), nil
 }
 
 // coalesceComponent takes a component, loads the chart and coalesces the configuration with the default values
@@ -237,6 +237,7 @@ func newComponentFromHelmRelease(release *release.Release) (*Component, error) {
 
 	cmp := NewComponent(
 		release.Name,
+		release.Namespace,
 		&Release{
 			Chart:   fmt.Sprintf("%s:%s", release.Chart.Metadata.Name, release.Chart.Metadata.Version),
 			Version: m.ReleaseVersion,

--- a/pkg/landscaper/component_test.go
+++ b/pkg/landscaper/component_test.go
@@ -8,12 +8,13 @@ import (
 )
 
 func makeTestComp() *Component {
-	return NewComponent("name", &Release{"cha", "1.1.1"}, map[string]interface{}{"config": "awesome"}, Secrets{"09F911029D74E35BD84156C5635688C0"})
+	return NewComponent("name", "default", &Release{"cha", "1.1.1"}, map[string]interface{}{"config": "awesome"}, Secrets{"09F911029D74E35BD84156C5635688C0"})
 }
 
 func TestComponentNew(t *testing.T) {
 	cAct := NewComponent(
 		"name",
+		"default",
 		&Release{"cha", "1.1.1"},
 		map[string]interface{}{"config": "awesome"},
 		Secrets{"09F911029D74E35BD84156C5635688C0"},
@@ -56,8 +57,8 @@ func TestComponentValidate(t *testing.T) {
 }
 
 func TestComponentEquals(t *testing.T) {
-	c0 := NewComponent("name", &Release{"cha", "1.1.1"}, map[string]interface{}{"config": "awesome"}, Secrets{"09F911029D74E35BD84156C5635688C0"})
-	c1 := NewComponent("name", &Release{"cha", "1.1.1"}, map[string]interface{}{"config": "awesome"}, Secrets{"09F911029D74E35BD84156C5635688C0"})
+	c0 := NewComponent("name", "default", &Release{"cha", "1.1.1"}, map[string]interface{}{"config": "awesome"}, Secrets{"09F911029D74E35BD84156C5635688C0"})
+	c1 := NewComponent("name", "default", &Release{"cha", "1.1.1"}, map[string]interface{}{"config": "awesome"}, Secrets{"09F911029D74E35BD84156C5635688C0"})
 	require.True(t, c0.Equals(c1))
 	c1.Name = "other"
 	require.False(t, c0.Equals(c1))

--- a/pkg/landscaper/executor.go
+++ b/pkg/landscaper/executor.go
@@ -130,9 +130,14 @@ func (e *executor) CreateComponent(cmp *Component) error {
 		}
 	}
 
+	namespace := cmp.Namespace
+	if cmp.Namespace == "" {
+		namespace = e.env.Namespace
+	}
+
 	_, err = e.env.HelmClient().InstallRelease(
 		chartPath,
-		e.env.Namespace,
+		namespace,
 		helm.ValueOverrides([]byte(rawValues)),
 		helm.ReleaseName(cmp.Name),
 		helm.InstallDryRun(e.env.DryRun),

--- a/pkg/landscaper/executor_test.go
+++ b/pkg/landscaper/executor_test.go
@@ -170,6 +170,7 @@ func TestIntegrateForcedUpdates(t *testing.T) {
 func newTestComponent() *Component {
 	cmp := NewComponent(
 		"create-test",
+		"default",
 		&Release{
 			Chart:   "connector-hdfs:0.1.0",
 			Version: "1.0.0",


### PR DESCRIPTION
This allows using an extra key in the landscape definition, `namespace`,
that overrides the default namespace (either default or the namespace
defined using --namespace).