### PR TITLE
allow to instruct landscaper to reject an empty landscape

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -105,6 +105,7 @@ func init() {
 	f.BoolVar(&env.NoCronUpdate, "no-cronjob-update", false, "replaces CronJob updates with a create+delete; k8s #35149 work around")
 	f.BoolVar(&env.Loop, "loop", false, "keep landscape in sync forever")
 	f.DurationVar(&env.LoopInterval, "loop-interval", 5*time.Minute, "when running in a loop the interval between invocations")
+	f.BoolVar(&env.RejectEmptyLandscape, "reject-empty-landscape", false, "when enabled, doesn't apply an empty desired landscape")
 
 	rootCmd.AddCommand(addCmd)
 }

--- a/example/README.md
+++ b/example/README.md
@@ -94,7 +94,7 @@ Loop mode is especially useful when watching a remote Git repository, so that wh
 
 Below is an example of a deployment that runs Landscaper as a container in a pod in loop mode. It is pointed to the local folder `/git/some-repo`. It shares this folder with a `git-sync` container which will populate the folder with the contents of the master branch of the Git repository at https://github.com/you/some-repo.git every minute.
 
-There's one gotcha, though: the very first Landscaper run after each pod creation will remove everything as the Git repo hasn't been synced yet. Use with caution until we find a way around that issue.
+There's one gotcha, though: the very first Landscaper run after each pod creation will remove everything as the Git repo hasn't been synced yet. This can be avoided by running landscaper with the `--reject-empty-landscape` flag.
 
 ```yaml
 apiVersion: extensions/v1beta1
@@ -119,6 +119,7 @@ spec:
         - --namespace=landscaper-test
         - --loop
         - --loop-interval=1m
+        - --reject-empty-landscape
         - --verbose
         volumeMounts:
         - mountPath: /git

--- a/pkg/landscaper/environment.go
+++ b/pkg/landscaper/environment.go
@@ -22,18 +22,19 @@ var tillerNamespace = "kube-system"
 
 // Environment contains all the information about the k8s cluster and local configuration
 type Environment struct {
-	HelmHome          string        // Helm's home directory
-	DryRun            bool          // If true, don't modify anything
-	ChartLoader       ChartLoader   // ChartLoader loads charts
-	ReleaseNamePrefix string        // Prepend this string to release names
-	ComponentFiles    []string      // Landscaper component file names
-	LandscapeDir      string        // deprecated: ComponentFiles is leading; LandscapeDir merely fills it
-	Namespace         string        // Default namespace releases are put into; components can override it though
-	Verbose           bool          // Reduce log level
-	NoCronUpdate      bool          // NoCronUpdate replaces a CronJob update with a create+delete; k8s #35149 work around
-	Context           string        // Kubernetes context to use
-	Loop              bool          // Keep looping
-	LoopInterval      time.Duration // Loop every duration
+	HelmHome             string        // Helm's home directory
+	DryRun               bool          // If true, don't modify anything
+	ChartLoader          ChartLoader   // ChartLoader loads charts
+	ReleaseNamePrefix    string        // Prepend this string to release names
+	ComponentFiles       []string      // Landscaper component file names
+	LandscapeDir         string        // deprecated: ComponentFiles is leading; LandscapeDir merely fills it
+	Namespace            string        // Default namespace releases are put into; components can override it though
+	Verbose              bool          // Reduce log level
+	NoCronUpdate         bool          // NoCronUpdate replaces a CronJob update with a create+delete; k8s #35149 work around
+	Context              string        // Kubernetes context to use
+	Loop                 bool          // Keep looping
+	LoopInterval         time.Duration // Loop every duration
+	RejectEmptyLandscape bool          // Do not apply if desired landscape is empty
 
 	helmClient helm.Interface
 	kubeClient internalversion.CoreInterface

--- a/pkg/landscaper/executor.go
+++ b/pkg/landscaper/executor.go
@@ -42,6 +42,11 @@ func NewExecutor(helmClient helm.Interface, chartLoader ChartLoader, kubeSecrets
 
 // Apply transforms the current state into the desired state
 func (e *executor) Apply(desired, current Components) error {
+	if len(desired) == 0 && e.env.RejectEmptyLandscape {
+		logrus.Infof("Skipped applying empty landscape")
+		return nil
+	}
+
 	create, update, delete := diff(desired, current)
 
 	// some to-be-updated components need a delete + create instead


### PR DESCRIPTION
This adds a flag `reject-empty-landscape` that doesn't apply a landscape when the desired list of components is empty, i.e. would wipe everything out. 

It solves the gotcha mentioned [here](https://github.com/Eneco/landscaper/tree/1.0.4/example#using-loop-mode-with-git-repository-sync) where the initial loop iteration applies an empty `landscape` because the git repo wasn't synced yet.

This can also be used to protect a user using `landscaper` on the command line when she accidentally picks the wrong landscape source folder.

Let me know what you think and if you'd like to have this feature. I know that `landscaper` is mainly used from the CLI where this flag is less useful and may just blow up the flags.