### PR TITLE
Fix: Set logging output to stdout

### DIFF
--- a/cmd/landscaper.go
+++ b/cmd/landscaper.go
@@ -33,6 +33,7 @@ func init() {
 		FullTimestamp:   true,
 	}
 	logrus.SetFormatter(p)
+	logrus.SetOutput(os.Stdout)
 }
 
 func main() {


### PR DESCRIPTION
While testing with

`$ landscaper apply ... >>out1 2>>out2`

all logging information is send to stderr (out2) instead of stdout (out1).