### PR TITLE
Allow landscape version to be optional

### DIFF
--- a/pkg/landscaper/release.go
+++ b/pkg/landscaper/release.go
@@ -3,5 +3,5 @@ package landscaper
 // Release contains the information of a component release
 type Release struct {
 	Chart   string `json:"chart" validate:"nonzero"` // TODO: write a regexp validation for the chart
-	Version string `json:"version" validate:"nonzero"`
+	Version string `json:"version"`
 }

--- a/test/landscapes/no-version/hello-world.yaml
+++ b/test/landscapes/no-version/hello-world.yaml
@@ -1,0 +1,5 @@
+name: hello-world
+release:
+  chart: local/hello-world:0.1.0
+configuration:
+  message: Hello, Landscaped world!


### PR DESCRIPTION
This allows the Release.Version to be unset.

Addresses https://github.com/Eneco/landscaper/issues/73

LMK if there are any changes you'd like or any ways I can clean up the tests.
(FYI: I'm new to go)