### PR TITLE
feat: wait for components to be ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ The `apply` command accepts the following arguments:
           --prefix string            prefix release names with this string instead of <namespace>; overrides LANDSCAPE_PREFIX
           --tiller-namespace string  Tiller namespace for Helm (default "kube-system")
       -v, --verbose                  be verbose
+          --wait                     wait for all resources to be ready
+          --wait-timeout duration    interval to wait for all resources to be ready (default 5m0s)
 
 Instead of using arguments, environment variables can be used. When arguments are present, they override environment variables.
 `--namespace` is used to isolate landscapes through Kubernetes namespaces.

--- a/pkg/landscaper/environment.go
+++ b/pkg/landscaper/environment.go
@@ -24,6 +24,8 @@ var tillerTunnel *kube.Tunnel
 type Environment struct {
 	HelmHome          string        // Helm's home directory
 	DryRun            bool          // If true, don't modify anything
+	Wait              bool          // Wait until all resources become ready
+	WaitTimeout       time.Duration // Wait for helm
 	ChartLoader       ChartLoader   // ChartLoader loads charts
 	ReleaseNamePrefix string        // Prepend this string to release names
 	ComponentFiles    []string      // Landscaper component file names

--- a/pkg/landscaper/executor.go
+++ b/pkg/landscaper/executor.go
@@ -25,15 +25,19 @@ type executor struct {
 	chartLoader ChartLoader
 	kubeSecrets SecretsWriteDeleter
 	dryRun      bool
+	wait        bool
+	waitTimeout int64
 }
 
 // NewExecutor is a factory method to create a new Executor
-func NewExecutor(helmClient helm.Interface, chartLoader ChartLoader, kubeSecrets SecretsWriteDeleter, dryRun bool) Executor {
+func NewExecutor(helmClient helm.Interface, chartLoader ChartLoader, kubeSecrets SecretsWriteDeleter, dryRun bool, wait bool, waitTimeout int64) Executor {
 	return &executor{
 		helmClient:  helmClient,
 		chartLoader: chartLoader,
 		kubeSecrets: kubeSecrets,
 		dryRun:      dryRun,
+		wait:        wait,
+		waitTimeout: waitTimeout,
 	}
 }
 
@@ -148,6 +152,8 @@ func (e *executor) CreateComponent(cmp *Component) error {
 		helm.ReleaseName(cmp.Name),
 		helm.InstallDryRun(e.dryRun),
 		helm.InstallReuseName(true),
+		helm.InstallWait(e.wait),
+		helm.InstallTimeout(e.waitTimeout),
 	)
 	if err != nil {
 		return errors.New(grpc.ErrorDesc(err))
@@ -198,6 +204,8 @@ func (e *executor) UpdateComponent(cmp *Component) error {
 		chartPath,
 		helm.UpdateValueOverrides([]byte(rawValues)),
 		helm.UpgradeDryRun(e.dryRun),
+		helm.UpgradeWait(e.wait),
+		helm.UpgradeTimeout(e.waitTimeout),
 	)
 	if err != nil {
 		return errors.New(grpc.ErrorDesc(err))

--- a/pkg/landscaper/executor_test.go
+++ b/pkg/landscaper/executor_test.go
@@ -11,6 +11,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	waitTimeout = 60
+)
+
 func TestExecutorDiff(t *testing.T) {
 	current := Components{
 		"cmpA": &Component{Name: "cmpA"},
@@ -77,7 +81,7 @@ func TestExecutorApply(t *testing.T) {
 		},
 	}
 
-	err := NewExecutor(helmMock, chartLoadMock, secretsMock, false).Apply(des, cur)
+	err := NewExecutor(helmMock, chartLoadMock, secretsMock, false, false, waitTimeout).Apply(des, cur)
 	require.NoError(t, err)
 
 }
@@ -107,7 +111,7 @@ func TestExecutorCreate(t *testing.T) {
 		return nil
 	}}
 
-	err := NewExecutor(helmMock, chartLoadMock, secretsMock, false).CreateComponent(comp)
+	err := NewExecutor(helmMock, chartLoadMock, secretsMock, false, false, waitTimeout).CreateComponent(comp)
 	require.NoError(t, err)
 }
 
@@ -141,7 +145,7 @@ func TestExecutorUpdate(t *testing.T) {
 		},
 	}
 
-	err := NewExecutor(helmMock, chartLoadMock, secretsMock, false).UpdateComponent(comp)
+	err := NewExecutor(helmMock, chartLoadMock, secretsMock, false, false, waitTimeout).UpdateComponent(comp)
 	require.NoError(t, err)
 }
 
@@ -167,7 +171,7 @@ func TestExecutorDelete(t *testing.T) {
 		return nil
 	}}
 
-	err := NewExecutor(helmMock, chartLoadMock, secretsMock, false).DeleteComponent(comp)
+	err := NewExecutor(helmMock, chartLoadMock, secretsMock, false, false, waitTimeout).DeleteComponent(comp)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
* Uses helm's option to wait until created resources are ready which in turn
  makes landscaper only exit when all components are ready.
* Adds 2 parameters:
  --wait instructs helm client to wait for resource to become ready (helm
  equivalent --wait, defaults to false)
  --wait-timeout time to wait for individual kubernetes operation (helm
  equivalent --timeout, defaults to 5min)