### PR TITLE
feat: Process requirements to support dependency aliases

### DIFF
--- a/pkg/landscaper/state_provider.go
+++ b/pkg/landscaper/state_provider.go
@@ -250,6 +250,11 @@ func (cp *fileStateProvider) coalesceComponent(cmp *Component) error {
 		return err
 	}
 
+	err = chartutil.ProcessRequirementsEnabled(ch, &chart.Config{Raw: raw})
+	if err != nil {
+		return err
+	}
+
 	helmValues, err := chartutil.CoalesceValues(ch, &chart.Config{Raw: raw})
 	if err != nil {
 		return err


### PR DESCRIPTION
I have a chart that uses dependency aliases (https://docs.helm.sh/developing_charts/#alias-field-in-requirements-yaml).

Landscaper was able to deploy it correctly but it would always try to update it, even when there was no changes at all. I investigated a little and found out that landscaper doesn't load the chart values correctly when using aliases. This breaks the diff between helm state and file state and makes Landscaper attempt an update.

By looking at Helm code I found out that the chart dependencies are actually updated in the "chartutil.ProcessRequirementsEnabled" method. This will add dependencies for aliases but also remove disable charts. I only tested this for dependencies aliases but I think that removing disabled charts is also something we want to do.

I have not added tests at this time. I'm not familiar enough with the code yet but I think that we would need to be able to inject the "chartutil.LoadRequirements" method somehow to test this.