### PR TITLE
feat: add azure keyvault support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,13 @@ The `apply` command accepts the following arguments:
       landscaper apply [files]... [flags]
     
     Flags:
-          --chart-dir string          (deprecated; use --helm-home) Helm home directory (default "/Users/zainmalik/.helm")
+          --azure-keyvault string     azure keyvault for fetching secrets. Azure credentials must be provided in the environment.
+          --chart-dir string          (deprecated; use --helm-home) Helm home directory (default "$HOME/.helm")
           --context string            the kube context to use. defaults to the current context
           --dir string                (deprecated) path to a folder that contains all the landscape desired state files; overrides LANDSCAPE_DIR
           --disable stringSlice       Stages to be disabled. Available stages are create/update/delete.
           --dry-run                   simulate the applying of the landscape. useful in merge requests
-          --helm-home string          Helm home directory (default "/Users/zainmalik/.helm")
+          --helm-home string          Helm home directory (default "$HOME/.helm")
           --loop                      keep landscape in sync forever
           --loop-interval duration    when running in a loop the interval between invocations (default 5m0s)
           --namespace string          namespace to apply the landscape to; overrides LANDSCAPE_NAMESPACE (default "default")
@@ -97,6 +98,13 @@ Currently, secrets are handled by specifying the name in the YAML, e.g. `my-secr
 Landscaper can also be run as a control loop that constantly watches the desired landscape and applies it to the cluster. With this you can deploy landscaper once in your cluster, pass it a reference to a landscape description and have Landscaper apply it whenever the landscape changes.
 
 Connection to Tiller is made by setting up a port-forward to it's pod. However, when `$HELM_HOST` is defined with a "host:port" in it, a direct connection is made to that host and port instead.
+
+### Azure Credentials
+When using the `--azure-keyvault` argument, Azure Service Principal credentials must be available in the environment:
+
+  - `AZURE_CLIENT_ID`
+  - `AZURE_CLIENT_SECRET`
+  - `AZURE_TENANT_ID`
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ When using the `--azure-keyvault` argument, Azure Service Principal credentials 
   - `AZURE_CLIENT_SECRET`
   - `AZURE_TENANT_ID`
 
+The key vault DNS suffix defaults to the public cloud, `vault.azure.net`, but can be overridden with `AZURE_KEYVAULT_DNS_SUFFIX`.
+
 ## Example
 
 An example is provided [here](./example).

--- a/glide.lock
+++ b/glide.lock
@@ -1,15 +1,29 @@
-hash: 26c05446ae9d01bac9d252748e3d425e4cd677f857d70551dc89fba109d774f8
-updated: 2017-07-27T10:49:00.046279409+02:00
+hash: 9504621c9a11511266a2a84e10c679847a43967879c9b603ee36e96d15548b00
+updated: 2017-10-03T22:44:35.974263229+02:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
   subpackages:
   - compute/metadata
   - internal
+- name: github.com/Azure/azure-sdk-for-go
+  version: 2592daf71ab6b95dcfc7f7437ecc1afb9ddb7360
+  subpackages:
+  - arm/examples/helpers
+  - dataplane/keyvault
 - name: github.com/Azure/go-ansiterm
   version: 70b2c90b260171e829f1ebd7c17f600c11858dbe
   subpackages:
   - winterm
+- name: github.com/Azure/go-autorest
+  version: f6be1abbb5abd0517522f850dd785990d373da7e
+  subpackages:
+  - autorest
+  - autorest/adal
+  - autorest/azure
+  - autorest/date
+  - autorest/to
+  - autorest/validation
 - name: github.com/BurntSushi/toml
   version: b26d9c308763d68093482582cea63d69be07a0f0
 - name: github.com/coreos/go-oidc
@@ -178,7 +192,9 @@ imports:
 - name: github.com/x-cray/logrus-prefixed-formatter
   version: 54b7cd10b359d569484cc6b6ffd21d4649dcd148
 - name: golang.org/x/crypto
-  version: d172538b2cfce0c13cee31e647d0367aa8cd2486
+  version: 9419663f5a44be8b34ca85f08abc5fe1be11f8a3
+  repo: https://github.com/golang/crypto.git
+  vcs: git
   subpackages:
   - cast5
   - openpgp
@@ -188,10 +204,14 @@ imports:
   - openpgp/errors
   - openpgp/packet
   - openpgp/s2k
+  - pkcs12
   - ssh/terminal
 - name: golang.org/x/net
-  version: e90d6d0afc4c315a0d87a568ae68577cc15149a0
+  version: 0a9397675ba34b2845f758fe3cd68828369c6517
+  repo: https://github.com/golang/net.git
+  vcs: git
   subpackages:
+  - .
   - context
   - context/ctxhttp
   - http2
@@ -209,17 +229,22 @@ imports:
   - jws
   - jwt
 - name: golang.org/x/sys
-  version: 02a66801d979d706a4b445e24e03916eeaa2a404
+  version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
   subpackages:
   - unix
+  - windows
 - name: golang.org/x/text
-  version: 2910a502d2bf9e43193af9d68ca516529614eed3
+  version: 1cbadb444a806fd9430d14ad08967ed91da4fa0a
+  repo: https://github.com/golang/text.git
+  vcs: git
   subpackages:
+  - .
   - cases
   - encoding
   - encoding/internal
   - encoding/internal/identifier
   - encoding/unicode
+  - internal
   - internal/tag
   - internal/utf8internal
   - language
@@ -440,7 +465,7 @@ imports:
   - pkg/urlutil
   - pkg/version
 - name: k8s.io/kubernetes
-  version: 313fd317f96265658831a576fafdd6ed85aaf428
+  version: 2f830d21be89a077189f60a2d0b8379b7e2ba533
   subpackages:
   - federation/apis/federation
   - federation/apis/federation/install

--- a/glide.yaml
+++ b/glide.yaml
@@ -35,10 +35,12 @@ import:
 - package: k8s.io/apimachinery
 - package: k8s.io/client-go
   version: =3.0.0
-- package: k8s.io/client-go/rest
-  version: =3.0.0
+  subpackages:
+  - rest
 - package: k8s.io/kubernetes
   version: 1.7.6
+- package: github.com/Azure/azure-sdk-for-go
+  version: ^11.0.0-beta
 testImport:
 - package: github.com/stretchr/testify
   version: ^1.1.4

--- a/pkg/landscaper/environment.go
+++ b/pkg/landscaper/environment.go
@@ -36,6 +36,7 @@ type Environment struct {
 	Loop              bool          // Keep looping
 	LoopInterval      time.Duration // Loop every duration
 	TillerNamespace   string        // where to install / use tiller
+	AzureKeyVault     string        // Azure keyvault to use for secrets if provided
 	helmClient        helm.Interface
 	kubeClient        internalversion.CoreInterface
 	DisabledStages    stringSlice // stages to disable during landscaper apply

--- a/pkg/landscaper/secrets.go
+++ b/pkg/landscaper/secrets.go
@@ -49,7 +49,7 @@ func NewKubeSecretsReadWriteDeleter(kubeClient internalversion.CoreInterface) Se
 }
 
 // NewEnvironmentSecretsReader creates a SecretsReader for secrets provided via environment variables
-func NewEnvironmentSecretsReader() SecretsReader {
+func NewEnvironmentSecretsReader() (SecretsReader) {
 	return &environmentSecrets{}
 }
 

--- a/pkg/landscaper/secrets_azure.go
+++ b/pkg/landscaper/secrets_azure.go
@@ -1,0 +1,74 @@
+package landscaper
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Sirupsen/logrus"
+
+	"github.com/Azure/azure-sdk-for-go/arm/examples/helpers"
+	"github.com/Azure/azure-sdk-for-go/dataplane/keyvault"
+	"github.com/Azure/go-autorest/autorest"
+)
+
+type AzureSecretsReader struct{
+	kvClient keyvault.ManagementClient
+	kvName string
+}
+
+func NewAzureSecretsReader(keyVault string) (SecretsReader, error) {
+	envVars := map[string]string{
+		"AZURE_CLIENT_ID":       os.Getenv("AZURE_CLIENT_ID"),
+		"AZURE_CLIENT_SECRET":   os.Getenv("AZURE_CLIENT_SECRET"),
+		"AZURE_TENANT_ID":       os.Getenv("AZURE_TENANT_ID"),
+	}
+
+	for varName, value := range envVars {
+		if value == "" {
+			logrus.WithField("variable", varName).Fatalf("Missing environment variable")
+			return nil, fmt.Errorf("azure client environment variable `%s` is empty", varName)
+		}
+	}
+	
+	resource := "https://vault.azure.net"
+	spt, err := helpers.NewServicePrincipalTokenFromCredentials(envVars, resource)
+	if err != nil {
+		logrus.WithField("error", err).Fatalf("Failed to get service principle token")
+		return nil, fmt.Errorf("failed to get azure service principal token")
+	}
+
+	kv := keyvault.New()
+	kv.Authorizer = autorest.NewBearerAuthorizer(spt)
+
+	return &AzureSecretsReader{kvClient: kv, kvName: keyVault}, nil
+}
+
+// Reads the secret from the Azure key vault
+func (asp *AzureSecretsReader) Read(componentName, namespace string, secretNames []string) (SecretValues, error) {
+	logrus.WithFields(logrus.Fields{"component": componentName, "namespace": namespace}).Debug("Reading secrets for component")
+	
+	secrets := SecretValues{}
+
+	baseURL := fmt.Sprintf("https://%s.vault.azure.net/", asp.kvName)
+
+	for _, secret := range secretNames {
+		value, err := asp.kvClient.GetSecret(baseURL, secret, "")
+		if err != nil {
+			logrus.WithFields(logrus.Fields{
+				"component": componentName, 
+				"namespace": namespace,
+				"keyvault": asp.kvName, 
+				"secret": secret, 
+			}).Error("Secret not found in keyvault")
+			return secrets, fmt.Errorf("secret `%s` was not found in keyvault `%s`", secret, asp.kvName)
+		}
+		secrets[secret] = []byte(*value.Value)
+	}
+
+	logrus.WithFields(logrus.Fields{
+		"component": componentName, 
+		"namespace": namespace,
+	}).Debug("Successfully read secrets for component")
+
+	return secrets, nil
+}


### PR DESCRIPTION
I have added a simple command line flag to specify (and implicitly enable) the azure key vault. I don't think this approach will scale as more external service integrations are added (hashicorp vault etc).