### PR TITLE
Environment overrides

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -31,7 +31,7 @@ var addCmd = &cobra.Command{
 
 		v := landscaper.GetVersion()
 		logrus.WithFields(logrus.Fields{"tag": v.GitTag, "commit": v.GitCommit}).Infof("This is Landscaper v%s", v.SemVer)
-		logrus.WithFields(logrus.Fields{"namespace": env.Namespace, "releasePrefix": env.ReleaseNamePrefix, "dir": env.LandscapeDir, "dryRun": env.DryRun, "wait": env.Wait, "waitTimeout": env.WaitTimeout, "helmHome": env.HelmHome, "verbose": env.Verbose}).Info("Apply landscape desired state")
+		logrus.WithFields(logrus.Fields{"namespace": env.Namespace, "releasePrefix": env.ReleaseNamePrefix, "dir": env.LandscapeDir, "dryRun": env.DryRun, "wait": env.Wait, "waitTimeout": env.WaitTimeout, "helmHome": env.HelmHome, "verbose": env.Verbose, "environment": env.Environment}).Info("Apply landscape desired state")
 
 		// deprecated: populate ComponentFiles by getting *.yaml from LandscapeDir
 		if len(args) == 0 && env.LandscapeDir != "" {
@@ -49,18 +49,18 @@ var addCmd = &cobra.Command{
 			}
 			secretsReader = azureSecretsReader
 		}
-		fileState := landscaper.NewFileStateProvider(env.ComponentFiles, secretsReader, env.ChartLoader, env.ReleaseNamePrefix, env.Namespace)
+		fileState := landscaper.NewFileStateProvider(env.ComponentFiles, secretsReader, env.ChartLoader, env.ReleaseNamePrefix, env.Namespace, env.Environment)
 		helmState := landscaper.NewHelmStateProvider(env.HelmClient(), kubeSecrets, env.ReleaseNamePrefix)
 		executor := landscaper.NewExecutor(env.HelmClient(), env.ChartLoader, kubeSecrets, env.DryRun, env.Wait, int64(env.WaitTimeout/time.Second), env.DisabledStages)
 
 		for {
-			desired, err := fileState.Components(env.Environment)
+			desired, err := fileState.Components()
 			if err != nil {
 				logrus.WithFields(logrus.Fields{"error": err}).Error("Loading desired state failed")
 				return err
 			}
 
-			current, err := helmState.Components(env.Environment)
+			current, err := helmState.Components()
 			if err != nil {
 				logrus.WithFields(logrus.Fields{"error": err}).Error("Loading current state failed")
 				return err
@@ -124,6 +124,6 @@ func init() {
 
 	f.StringVar(&env.AzureKeyVault, "azure-keyvault", "", "azure keyvault for fetching secrets. Azure credentials must be provided in the environment.")
 	f.StringVar(&env.Environment, "env", "", "environment specifier. selects value overrides by environment.")
-    
+
 	rootCmd.AddCommand(addCmd)
 }

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -54,13 +54,13 @@ var addCmd = &cobra.Command{
 		executor := landscaper.NewExecutor(env.HelmClient(), env.ChartLoader, kubeSecrets, env.DryRun, env.Wait, int64(env.WaitTimeout/time.Second), env.DisabledStages)
 
 		for {
-			desired, err := fileState.Components()
+			desired, err := fileState.Components(env.Environment)
 			if err != nil {
 				logrus.WithFields(logrus.Fields{"error": err}).Error("Loading desired state failed")
 				return err
 			}
 
-			current, err := helmState.Components()
+			current, err := helmState.Components(env.Environment)
 			if err != nil {
 				logrus.WithFields(logrus.Fields{"error": err}).Error("Loading current state failed")
 				return err
@@ -123,5 +123,7 @@ func init() {
 	f.DurationVar(&env.LoopInterval, "loop-interval", 5*time.Minute, "when running in a loop the interval between invocations")
 
 	f.StringVar(&env.AzureKeyVault, "azure-keyvault", "", "azure keyvault for fetching secrets. Azure credentials must be provided in the environment.")
+	f.StringVar(&env.Environment, "env", "", "environment specifier. selects value overrides by environment.")
+    
 	rootCmd.AddCommand(addCmd)
 }

--- a/pkg/landscaper/component.go
+++ b/pkg/landscaper/component.go
@@ -9,23 +9,25 @@ import (
 
 // Component contains information about the release, configuration and secrets of a component
 type Component struct {
-	Name          string        `json:"name" validate:"nonzero,max=51"`
-	Namespace     string        `json:"namespace"`
-	Release       *Release      `json:"release" validate:"nonzero"`
-	Configuration Configuration `json:"configuration"`
-	Secrets       Secrets       `json:"secrets"`
-	SecretValues  SecretValues  `json:"-"`
+	Name          string         `json:"name" validate:"nonzero,max=51"`
+	Namespace     string         `json:"namespace"`
+	Release       *Release       `json:"release" validate:"nonzero"`
+	Configuration Configuration  `json:"configuration"`
+	Environments  Configurations `json:"environments"`
+	Secrets       Secrets        `json:"secrets"`
+	SecretValues  SecretValues   `json:"-"`
 }
 
 // Components is a collection of uniquely named Component objects
 type Components map[string]*Component
 
 // NewComponent creates a Component and adds Name to the configuration
-func NewComponent(name string, namespace string, release *Release, cfg Configuration, secrets Secrets) *Component {
+func NewComponent(name string, namespace string, release *Release, cfg Configuration, envs Configurations, secrets Secrets) *Component {
 	cmp := &Component{
 		Name:          name,
 		Release:       release,
 		Configuration: cfg,
+		Environments:  envs,
 		Secrets:       secrets,
 		SecretValues:  SecretValues{},
 		Namespace:     namespace,
@@ -33,6 +35,10 @@ func NewComponent(name string, namespace string, release *Release, cfg Configura
 
 	if cmp.Configuration == nil {
 		cmp.Configuration = Configuration{}
+	}
+
+	if cmp.Environments == nil {
+		cmp.Environments = Configurations{}
 	}
 
 	if cmp.Secrets == nil {

--- a/pkg/landscaper/component_test.go
+++ b/pkg/landscaper/component_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func makeTestComp() *Component {
-	return NewComponent("name", "someNameSpace", &Release{"cha", "1.1.1"}, map[string]interface{}{"config": "awesome"}, Secrets{"09F911029D74E35BD84156C5635688C0"})
+	return NewComponent("name", "someNameSpace", &Release{"cha", "1.1.1"}, map[string]interface{}{"config": "awesome"}, Configurations{}, Secrets{"09F911029D74E35BD84156C5635688C0"})
 }
 
 func TestComponentNew(t *testing.T) {
@@ -17,6 +17,7 @@ func TestComponentNew(t *testing.T) {
 		"someNameSpace",
 		&Release{"cha", "1.1.1"},
 		map[string]interface{}{"config": "awesome"},
+		Configurations{},
 		Secrets{"09F911029D74E35BD84156C5635688C0"},
 	)
 
@@ -25,6 +26,7 @@ func TestComponentNew(t *testing.T) {
 		Namespace:     "someNameSpace",
 		Release:       &Release{"cha", "1.1.1"},
 		Configuration: map[string]interface{}{"config": "awesome"},
+		Environments:  Configurations{},
 		Secrets:       Secrets{"09F911029D74E35BD84156C5635688C0"},
 		SecretValues:  SecretValues{},
 	}
@@ -58,8 +60,8 @@ func TestComponentValidate(t *testing.T) {
 }
 
 func TestComponentEquals(t *testing.T) {
-	c0 := NewComponent("name", "default", &Release{"cha", "1.1.1"}, map[string]interface{}{"config": "awesome"}, Secrets{"09F911029D74E35BD84156C5635688C0"})
-	c1 := NewComponent("name", "default", &Release{"cha", "1.1.1"}, map[string]interface{}{"config": "awesome"}, Secrets{"09F911029D74E35BD84156C5635688C0"})
+	c0 := NewComponent("name", "default", &Release{"cha", "1.1.1"}, map[string]interface{}{"config": "awesome"}, Configurations{}, Secrets{"09F911029D74E35BD84156C5635688C0"})
+	c1 := NewComponent("name", "default", &Release{"cha", "1.1.1"}, map[string]interface{}{"config": "awesome"}, Configurations{}, Secrets{"09F911029D74E35BD84156C5635688C0"})
 	require.True(t, c0.Equals(c1))
 	c1.Name = "other"
 	require.False(t, c0.Equals(c1))

--- a/pkg/landscaper/configuration.go
+++ b/pkg/landscaper/configuration.go
@@ -3,11 +3,13 @@ package landscaper
 import (
 	"fmt"
 
-	"gopkg.in/yaml.v2"
+	"github.com/ghodss/yaml"
 )
 
 // Configuration contains all the values that should be applied to the component's helm package release
 type Configuration map[string]interface{}
+
+type Configurations map[string]Configuration
 
 // YAML encodes the Values into a YAML string.
 func (cfg Configuration) YAML() (string, error) {
@@ -40,3 +42,41 @@ func (cfg Configuration) SetMetadata(m *Metadata) {
 		metaChartRepo:      m.ChartRepository,
 	}
 }
+
+func (dest Configuration) Merge(src Configuration) Configuration {
+	return mergeValues(dest, src)
+}
+
+func mergeValues(dest, src Configuration) (Configuration) {
+	for k, v := range src {
+
+		// If the key doesn't exist already, then just set the key to that value
+		if _, exists := dest[k]; !exists {
+			dest[k] = v
+			continue
+		}
+
+		// If it isn't another map, overwrite the value
+		nextMap, ok := v.(map[string]interface{})
+		if !ok {
+			dest[k] = v
+			continue
+		}
+		// If the key doesn't exist already, then just set the key to that value
+		if _, exists := dest[k]; !exists {
+			dest[k] = nextMap
+			continue
+		}
+		// Edge case: If the key exists in the destination, but isn't a map
+		destMap, isMap := dest[k].(map[string]interface{})
+		// If the source map has a map for this key, prefer it
+		if !isMap {
+			dest[k] = v
+			continue
+		}
+		// If we got to this point, it is a map in both, so merge them
+		dest[k] = mergeValues(destMap, nextMap)
+	}
+	return dest
+}
+

--- a/pkg/landscaper/environment.go
+++ b/pkg/landscaper/environment.go
@@ -37,6 +37,7 @@ type Environment struct {
 	LoopInterval      time.Duration // Loop every duration
 	TillerNamespace   string        // where to install / use tiller
 	AzureKeyVault     string        // Azure keyvault to use for secrets if provided
+	Environment       string        // Environment selections
 	helmClient        helm.Interface
 	kubeClient        internalversion.CoreInterface
 	DisabledStages    stringSlice // stages to disable during landscaper apply

--- a/pkg/landscaper/executor_test.go
+++ b/pkg/landscaper/executor_test.go
@@ -277,6 +277,7 @@ func newTestComponent(name string) *Component {
 			"FlushSize":                  3,
 			"FilenameOffsetZeroPadWidth": 1,
 		},
+		Configurations{},
 		Secrets{"TestSecret1", "TestSecret2"},
 	)
 

--- a/pkg/landscaper/state_provider_test.go
+++ b/pkg/landscaper/state_provider_test.go
@@ -44,8 +44,8 @@ ref: %s
 	// covers both the dir/*.yaml function as explicit files
 	for _, ps := range [][]string{{rigsDir}, {rigsDir + "hello-world.yaml", rigsDir + "secretive2.yaml", rigsDir + "secretive.yaml"}} {
 
-		fs := NewFileStateProvider(ps, secretsMock, chartLoadMock, "pfx-", "spa")
-		cs, err := fs.Components("")
+		fs := NewFileStateProvider(ps, secretsMock, chartLoadMock, "pfx-", "spa", "")
+		cs, err := fs.Components()
 		require.NoError(t, err)
 		require.Len(t, cs, 3)
 		require.Contains(t, cs, "pfx-hello-world")
@@ -109,8 +109,8 @@ ref: %s
 		return c, "", nil
 	})
 
-	fs := NewFileStateProvider([]string{"../../test/landscapes/no-version/hello-world.yaml"}, secretsMock, chartLoadMock, "pfx-", "spa")
-	cs, err := fs.Components("")
+	fs := NewFileStateProvider([]string{"../../test/landscapes/no-version/hello-world.yaml"}, secretsMock, chartLoadMock, "pfx-", "spa", "")
+	cs, err := fs.Components()
 	require.NoError(t, err)
 	c0 := cs["pfx-hello-world"]
 
@@ -157,7 +157,7 @@ config_c: qqq
 	}
 
 	hs := NewHelmStateProvider(helmMock, secretsMock, "my-prefix")
-	cmps, err := hs.Components("")
+	cmps, err := hs.Components()
 	require.NoError(t, err)
 	require.Len(t, cmps, 1)
 	require.Contains(t, cmps, "my-release")
@@ -197,24 +197,25 @@ ref: %s
 		return c, "", nil
 	})
 
-	fs := NewFileStateProvider([]string{"../../test/landscapes/environments/hello-world.yaml"}, secretsMock, chartLoadMock, "pfx-", "spa")
-	
 	// No environment
-	cs, err := fs.Components("")
+	fs := NewFileStateProvider([]string{"../../test/landscapes/environments/hello-world.yaml"}, secretsMock, chartLoadMock, "pfx-", "spa", "")
+	cs, err := fs.Components()
 	require.NoError(t, err)
 	c0 := cs["pfx-hello-world"]
 	require.Equal(t, "Hello, Landscaped world!", c0.Configuration["message"])
 	require.Equal(t, nil, c0.Configuration["extra"])
 
 	// Env1
-	cs, err = fs.Components("env1")
+	fs = NewFileStateProvider([]string{"../../test/landscapes/environments/hello-world.yaml"}, secretsMock, chartLoadMock, "pfx-", "spa", "env1")
+	cs, err = fs.Components()
 	require.NoError(t, err)
 	c0 = cs["pfx-hello-world"]
 	require.Equal(t, "env1 overwrite", c0.Configuration["message"])
 	require.Equal(t, "env1 extra", c0.Configuration["extra"])
 
 	// Env2
-	cs, err = fs.Components("env2")
+	fs = NewFileStateProvider([]string{"../../test/landscapes/environments/hello-world.yaml"}, secretsMock, chartLoadMock, "pfx-", "spa", "env2")
+	cs, err = fs.Components()
 	require.NoError(t, err)
 	c0 = cs["pfx-hello-world"]
 	require.Equal(t, "env2 overwrite", c0.Configuration["message"])

--- a/test/landscapes/environments/hello-world.yaml
+++ b/test/landscapes/environments/hello-world.yaml
@@ -1,0 +1,12 @@
+name: hello-world
+release:
+  chart: local/hello-world:0.1.0
+  version: 0.1.0
+configuration:
+  message: Hello, Landscaped world!
+environments:
+  env1:
+    message: env1 overwrite
+    extra: env1 extra
+  env2:
+    message: env2 overwrite


### PR DESCRIPTION
This is a proposal for managing differences between environments when using the landscaper. It adds another section `environments` to the desired state file with optional overrides for values in the `configuration` section. The environments are named, and can be selected with the `--env` flag at deployment time. 

See the updates the the README for an example.