### PR TITLE
Update logrus and pin one dependency

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/eneco/landscaper/pkg/landscaper"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/landscaper.go
+++ b/cmd/landscaper.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	prefixed "github.com/x-cray/logrus-prefixed-formatter"
 )

--- a/glide.lock
+++ b/glide.lock
@@ -179,8 +179,8 @@ imports:
   version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
 - name: github.com/PuerkitoBio/urlesc
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
-- name: github.com/Sirupsen/logrus
-  version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
+- name: github.com/sirupsen/logrus
+  version: f006c2ac4710855cf0f916dd6b77acf6b048dc6e
 - name: github.com/spf13/cobra
   version: f62e98d28ab7ad31d707ba837a966378465c7b57
 - name: github.com/spf13/pflag
@@ -190,7 +190,7 @@ imports:
   subpackages:
   - codec
 - name: github.com/x-cray/logrus-prefixed-formatter
-  version: 54b7cd10b359d569484cc6b6ffd21d4649dcd148
+  version: bb2702d423886830dee131692131d35648c382e2
 - name: golang.org/x/crypto
   version: 9419663f5a44be8b34ca85f08abc5fe1be11f8a3
   repo: https://github.com/golang/crypto.git

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/eneco/landscaper
 import:
-- package: github.com/Sirupsen/logrus
-  version: =0.11.5
+- package: github.com/sirupsen/logrus
+  version: ~1.0.3
 - package: github.com/pmezard/go-difflib
   subpackages:
   - difflib

--- a/pkg/landscaper/chart.go
+++ b/pkg/landscaper/chart.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 
 	"k8s.io/helm/pkg/chartutil"
 	"k8s.io/helm/pkg/downloader"

--- a/pkg/landscaper/environment.go
+++ b/pkg/landscaper/environment.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	restclient "k8s.io/client-go/rest"

--- a/pkg/landscaper/executor.go
+++ b/pkg/landscaper/executor.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"reflect"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/pmezard/go-difflib/difflib"
+	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"k8s.io/helm/pkg/helm"
 )

--- a/pkg/landscaper/secrets.go
+++ b/pkg/landscaper/secrets.go
@@ -6,7 +6,7 @@ import (
 
 	"fmt"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/api"

--- a/pkg/landscaper/secrets_azure.go
+++ b/pkg/landscaper/secrets_azure.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 
 	"github.com/Azure/azure-sdk-for-go/arm/examples/helpers"
 	"github.com/Azure/azure-sdk-for-go/dataplane/keyvault"

--- a/pkg/landscaper/state_provider.go
+++ b/pkg/landscaper/state_provider.go
@@ -9,8 +9,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/ghodss/yaml"
+	"github.com/sirupsen/logrus"
 	validator "gopkg.in/validator.v2"
 	"k8s.io/helm/pkg/chartutil"
 	"k8s.io/helm/pkg/helm"


### PR DESCRIPTION
landscaper currently fails building because the logrus import changed.

This is a bit hacky as I modify `glide.lock` directly which breaks the hashing. Though, it was broken before, so...

How:
* update logrus to 1.0 and rename imports to lowercase
* pin `github.com/x-cray/logrus-prefixed-formatter` to the newest version which references it by lowercase too

/cc @otaviof 