### PR TITLE
feat: add global configuration override file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,23 +70,24 @@ The `apply` command accepts the following arguments:
       landscaper apply [files]... [flags]
     
     Flags:
-          --azure-keyvault string     azure keyvault for fetching secrets. Azure credentials must be provided in the environment.
-          --chart-dir string          (deprecated; use --helm-home) Helm home directory (default "$HOME/.helm")
-          --context string            the kube context to use. defaults to the current context
-          --dir string                (deprecated) path to a folder that contains all the landscape desired state files; overrides LANDSCAPE_DIR
-          --disable stringSlice       Stages to be disabled. Available stages are create/update/delete.
-          --dry-run                   simulate the applying of the landscape. useful in merge requests
-          --helm-home string          Helm home directory (default "$HOME/.helm")
-          --env string                environment specifier. selects value overrides by environment.
-          --loop                      keep landscape in sync forever
-          --loop-interval duration    when running in a loop the interval between invocations (default 5m0s)
-          --namespace string          namespace to apply the landscape to; overrides LANDSCAPE_NAMESPACE (default "default")
-          --no-prefix                 disable prefixing release names
-          --prefix string             prefix release names with this string instead of <namespace>; overrides LANDSCAPE_PREFIX
-          --tiller-namespace string   Tiller namespace for Helm (default "kube-system")
-      -v, --verbose                   be verbose
-          --wait                      wait for all resources to be ready
-          --wait-timeout duration     interval to wait for all resources to be ready (default 5m0s)
+          --azure-keyvault string         azure keyvault for fetching secrets. Azure credentials must be provided in the environment.
+          --chart-dir string              (deprecated; use --helm-home) Helm home directory (default "$HOME/.helm")
+          --config-override-file string   global configuration overrides. component specific environment overrides take precedence over this.
+          --context string                the kube context to use. defaults to the current context
+          --dir string                    (deprecated) path to a folder that contains all the landscape desired state files; overrides LANDSCAPE_DIR
+          --disable stringSlice           Stages to be disabled. Available stages are create/update/delete.
+          --dry-run                       simulate the applying of the landscape. useful in merge requests
+          --helm-home string              Helm home directory (default "$HOME/.helm")
+          --env string                    environment specifier. selects value overrides by environment.
+          --loop                          keep landscape in sync forever
+          --loop-interval duration        when running in a loop the interval between invocations (default 5m0s)
+          --namespace string              namespace to apply the landscape to; overrides LANDSCAPE_NAMESPACE (default "default")
+          --no-prefix                     disable prefixing release names
+          --prefix string                 prefix release names with this string instead of <namespace>; overrides LANDSCAPE_PREFIX
+          --tiller-namespace string       Tiller namespace for Helm (default "kube-system")
+      -v, --verbose                       be verbose
+          --wait                          wait for all resources to be ready
+          --wait-timeout duration         interval to wait for all resources to be ready (default 5m0s)
 
 Instead of using arguments, environment variables can be used. When arguments are present, they override environment variables.
 `--namespace` is used to isolate landscapes through Kubernetes namespaces.
@@ -147,6 +148,35 @@ and a Kubernetes secret named `default-my-component` with the contents:
     my-other-secret: <value MY_OTHER_SECRET environment variable>
     
 Currently, secrets are handled by specifying the name in the YAML, e.g. `my-secret`, and having a matching environment variable available with the secret, e.g. `export MY_SECRET=Rumpelstiltskin`
+    
+### Global configuration override file
+
+You can specify a global configuration override file with the `--config-override-file` argument. This will override chart and component defaults, but not environment specific configuration.
+
+    # my-component.yaml
+    name: my-component
+    release:
+      chart: "example/chart:0.1.0"
+      version: 0.1.0
+    
+    # This will become the .Values override for the chart deployment.
+    configuration:
+      hostname: "example"
+      url: "http://default.example.com"
+    environments:
+      env1:
+        hostname: "env1"
+    
+
+    
+    # global.yaml
+    hostname: "global"
+    url: "http://global.example.com"
+
+Installing the above component with `--config-override-file global.yaml` and `--env env1` will result in chart value overrides
+    
+    hostname: "env1"
+    url: "http://global.example.com"
     
 ### Secret Usage in Helm Charts
 Secrets are made available as Kubernetes Secrets (as shown above). The helm chart needs to be setup to [use the secret in a pod](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets), where the secret name is made available by the landscaper as `.Values.secretsRef`. For example, as an environment variable:

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -49,7 +49,7 @@ var addCmd = &cobra.Command{
 			}
 			secretsReader = azureSecretsReader
 		}
-		fileState := landscaper.NewFileStateProvider(env.ComponentFiles, secretsReader, env.ChartLoader, env.ReleaseNamePrefix, env.Namespace, env.Environment)
+		fileState := landscaper.NewFileStateProvider(env.ComponentFiles, secretsReader, env.ChartLoader, env.ReleaseNamePrefix, env.Namespace, env.Environment, env.ConfigurationOverrideFile)
 		helmState := landscaper.NewHelmStateProvider(env.HelmClient(), kubeSecrets, env.ReleaseNamePrefix)
 		executor := landscaper.NewExecutor(env.HelmClient(), env.ChartLoader, kubeSecrets, env.DryRun, env.Wait, int64(env.WaitTimeout/time.Second), env.DisabledStages)
 
@@ -124,6 +124,7 @@ func init() {
 
 	f.StringVar(&env.AzureKeyVault, "azure-keyvault", "", "azure keyvault for fetching secrets. Azure credentials must be provided in the environment.")
 	f.StringVar(&env.Environment, "env", "", "environment specifier. selects value overrides by environment.")
+	f.StringVar(&env.ConfigurationOverrideFile, "config-override-file", "", "global configuration override YAML file. component specific environment overrides take precedence over this.")
 
 	rootCmd.AddCommand(addCmd)
 }

--- a/pkg/landscaper/environment.go
+++ b/pkg/landscaper/environment.go
@@ -22,25 +22,26 @@ var tillerTunnel *kube.Tunnel
 
 // Environment contains all the information about the k8s cluster and local configuration
 type Environment struct {
-	HelmHome          string        // Helm's home directory
-	DryRun            bool          // If true, don't modify anything
-	Wait              bool          // Wait until all resources become ready
-	WaitTimeout       time.Duration // Wait for helm
-	ChartLoader       ChartLoader   // ChartLoader loads charts
-	ReleaseNamePrefix string        // Prepend this string to release names
-	ComponentFiles    []string      // Landscaper component file names
-	LandscapeDir      string        // deprecated: ComponentFiles is leading; LandscapeDir merely fills it
-	Namespace         string        // Default namespace releases are put into; components can override it though
-	Verbose           bool          // Reduce log level
-	Context           string        // Kubernetes context to use
-	Loop              bool          // Keep looping
-	LoopInterval      time.Duration // Loop every duration
-	TillerNamespace   string        // where to install / use tiller
-	AzureKeyVault     string        // Azure keyvault to use for secrets if provided
-	Environment       string        // Environment selections
-	helmClient        helm.Interface
-	kubeClient        internalversion.CoreInterface
-	DisabledStages    stringSlice // stages to disable during landscaper apply
+	HelmHome                  string        // Helm's home directory
+	DryRun                    bool          // If true, don't modify anything
+	Wait                      bool          // Wait until all resources become ready
+	WaitTimeout               time.Duration // Wait for helm
+	ChartLoader               ChartLoader   // ChartLoader loads charts
+	ReleaseNamePrefix         string        // Prepend this string to release names
+	ComponentFiles            []string      // Landscaper component file names
+	LandscapeDir              string        // deprecated: ComponentFiles is leading; LandscapeDir merely fills it
+	Namespace                 string        // Default namespace releases are put into; components can override it though
+	Verbose                   bool          // Reduce log level
+	Context                   string        // Kubernetes context to use
+	Loop                      bool          // Keep looping
+	LoopInterval              time.Duration // Loop every duration
+	TillerNamespace           string        // where to install / use tiller
+	AzureKeyVault             string        // Azure keyvault to use for secrets if provided
+	Environment               string        // Environment selections
+	ConfigurationOverrideFile string        // Global configuration overrides file
+	helmClient                helm.Interface
+	kubeClient                internalversion.CoreInterface
+	DisabledStages            stringSlice // stages to disable during landscaper apply
 }
 
 type stringSlice []string

--- a/pkg/landscaper/state_provider_test.go
+++ b/pkg/landscaper/state_provider_test.go
@@ -44,7 +44,7 @@ ref: %s
 	// covers both the dir/*.yaml function as explicit files
 	for _, ps := range [][]string{{rigsDir}, {rigsDir + "hello-world.yaml", rigsDir + "secretive2.yaml", rigsDir + "secretive.yaml"}} {
 
-		fs := NewFileStateProvider(ps, secretsMock, chartLoadMock, "pfx-", "spa", "")
+		fs := NewFileStateProvider(ps, secretsMock, chartLoadMock, "pfx-", "spa", "", "")
 		cs, err := fs.Components()
 		require.NoError(t, err)
 		require.Len(t, cs, 3)
@@ -109,7 +109,7 @@ ref: %s
 		return c, "", nil
 	})
 
-	fs := NewFileStateProvider([]string{"../../test/landscapes/no-version/hello-world.yaml"}, secretsMock, chartLoadMock, "pfx-", "spa", "")
+	fs := NewFileStateProvider([]string{"../../test/landscapes/no-version/hello-world.yaml"}, secretsMock, chartLoadMock, "pfx-", "spa", "", "")
 	cs, err := fs.Components()
 	require.NoError(t, err)
 	c0 := cs["pfx-hello-world"]
@@ -198,7 +198,7 @@ ref: %s
 	})
 
 	// No environment
-	fs := NewFileStateProvider([]string{"../../test/landscapes/environments/hello-world.yaml"}, secretsMock, chartLoadMock, "pfx-", "spa", "")
+	fs := NewFileStateProvider([]string{"../../test/landscapes/environments/hello-world.yaml"}, secretsMock, chartLoadMock, "pfx-", "spa", "", "")
 	cs, err := fs.Components()
 	require.NoError(t, err)
 	c0 := cs["pfx-hello-world"]
@@ -206,7 +206,7 @@ ref: %s
 	require.Equal(t, nil, c0.Configuration["extra"])
 
 	// Env1
-	fs = NewFileStateProvider([]string{"../../test/landscapes/environments/hello-world.yaml"}, secretsMock, chartLoadMock, "pfx-", "spa", "env1")
+	fs = NewFileStateProvider([]string{"../../test/landscapes/environments/hello-world.yaml"}, secretsMock, chartLoadMock, "pfx-", "spa", "env1", "")
 	cs, err = fs.Components()
 	require.NoError(t, err)
 	c0 = cs["pfx-hello-world"]
@@ -214,10 +214,26 @@ ref: %s
 	require.Equal(t, "env1 extra", c0.Configuration["extra"])
 
 	// Env2
-	fs = NewFileStateProvider([]string{"../../test/landscapes/environments/hello-world.yaml"}, secretsMock, chartLoadMock, "pfx-", "spa", "env2")
+	fs = NewFileStateProvider([]string{"../../test/landscapes/environments/hello-world.yaml"}, secretsMock, chartLoadMock, "pfx-", "spa", "env2", "")
 	cs, err = fs.Components()
 	require.NoError(t, err)
 	c0 = cs["pfx-hello-world"]
 	require.Equal(t, "env2 overwrite", c0.Configuration["message"])
 	require.Equal(t, nil, c0.Configuration["extra"])
+
+	// Global override
+	fs = NewFileStateProvider([]string{"../../test/landscapes/environments/hello-world.yaml"}, secretsMock, chartLoadMock, "pfx-", "spa", "", "../../test/landscapes/environments/global-override.yaml")
+	cs, err = fs.Components()
+	require.NoError(t, err)
+	c0 = cs["pfx-hello-world"]
+	require.Equal(t, "global configuration override", c0.Configuration["message"])
+	require.Equal(t, "global extra", c0.Configuration["extra"])
+
+	// Global override + Env2
+	fs = NewFileStateProvider([]string{"../../test/landscapes/environments/hello-world.yaml"}, secretsMock, chartLoadMock, "pfx-", "spa", "env2", "../../test/landscapes/environments/global-override.yaml")
+	cs, err = fs.Components()
+	require.NoError(t, err)
+	c0 = cs["pfx-hello-world"]
+	require.Equal(t, "env2 overwrite", c0.Configuration["message"])
+	require.Equal(t, "global extra", c0.Configuration["extra"])
 }

--- a/test/landscapes/environments/global-override.yaml
+++ b/test/landscapes/environments/global-override.yaml
@@ -1,0 +1,2 @@
+message: global configuration override
+extra: global extra


### PR DESCRIPTION
This allows specifying a configuration override file that will override chart and component defaults, but not environment overrides in the component.

My use case is I want to apply a global configuration to all components deployed to a particular environment, eg.:

    ingressSuffix: 'staging.example.com'
    environment:   'staging'