### PR TITLE
Provide a way to avoid deleting the secrets during the update

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -88,6 +88,12 @@ Upon success, `kubectl get secret --namespace example` should contain a Secret o
 
     Tue Dec 20 08:34:10 UTC 2016 | my name is rumpelstiltskin and I am 42 years old
 
+### Updating secrets
+
+By default landscaper always delete the old secrets during the update of a component. 
+
+A workaround to avoid deleting the old secrets with the same name as of the component you can use the flag `--disable deleteSecrets` during the landscaper apply.
+That would only work if the new landscaper object have no secrets. 
 ## Using Loop mode with Git repository sync
 
 Loop mode is especially useful when watching a remote Git repository, so that whenever a PR got merged Landscaper will automatically apply the changes. We can use the Git repo sync image to constantly check out the latest commit of a branch and share this path with Landscaper running as a separate container in the same pod.

--- a/pkg/landscaper/executor.go
+++ b/pkg/landscaper/executor.go
@@ -198,7 +198,9 @@ func (e *executor) UpdateComponent(cmp *Component) error {
 	}
 
 	if !e.dryRun {
-		err = e.kubeSecrets.Delete(cmp.Name, cmp.Namespace)
+		if e.stageEnabled("deleteSecrets") || len(cmp.Secrets) > 0 {
+			err = e.kubeSecrets.Delete(cmp.Name, cmp.Namespace)
+		}
 
 		if len(cmp.Secrets) > 0 {
 			err = e.kubeSecrets.Write(cmp.Name, cmp.Namespace, cmp.SecretValues)


### PR DESCRIPTION
This PR tries to provide a workaround for the issue: #101 

Before:
```
Landscaper would first delete the secrets of a component in the update, regardless if new secrets are provided or not
```

Now:
```
Landscaper would first delete the secrets of a component in the update, regardless if new secrets are provided or not.

Unless the flag "--disable deleteSecrets" is provided during the apply. But in the case, new secrets are provided it will delete the old secrets regardless of the flag.
```
