### PR TITLE
feat: support secrets as a map with alternate keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ is realised as:
     my-other-secret: <value MY_OTHER_SECRET environment variable>
 ```
 
-If a map is provided the key is the used in the Kubernetes secret key, and the value is used to fetch the secret value.
+If a map is provided the key is the used as the Kubernetes secret key, and the value is used to fetch the secret value.
 
 ```
 ...

--- a/README.md
+++ b/README.md
@@ -143,11 +143,43 @@ Installing the above component with `default` prefix and `--env dev` will result
     secretsRef: 'default-my-component'
     
 and a Kubernetes secret named `default-my-component` with the contents:
+
     
+#### Secrets
+
+Secrets can be provided as a list or as a map. If a list is provided then the same string is used for the key in the Kubernetes secret and to find the secret value.
+
+```
+...
+secrets:
+	- my-secret
+	- my-other-secret
+```
+
+is realised as:
+
+```
     my-secret: <value of MY_SECRET environment variable>
     my-other-secret: <value MY_OTHER_SECRET environment variable>
+```
+
+If a map is provided the key is the used in the Kubernetes secret key, and the value is used to fetch the secret value.
+
+```
+...
+secrets:
+	secret1: my-secret
+	secret2: my-other-secret
+```
+
+is realised as:
+
+```
+    secret1: <value of MY_SECRET environment variable>
+    secret2: <value MY_OTHER_SECRET environment variable>
+```
     
-Currently, secrets are handled by specifying the name in the YAML, e.g. `my-secret`, and having a matching environment variable available with the secret, e.g. `export MY_SECRET=Rumpelstiltskin`
+By default the secrets are read from the environment with the string converted to `UPPER_SNAKE_CASE` e.g. `export MY_SECRET=Rumpelstiltskin`
     
 ### Global configuration override file
 
@@ -167,7 +199,7 @@ You can specify a global configuration override file with the `--config-override
       env1:
         hostname: "env1"
     
-
+ 
     
     # global.yaml
     hostname: "global"
@@ -231,6 +263,8 @@ Landscaper uses both Helm and Kubernetes. The following Landscaper releases are 
 
 | Landscaper | Helm  | Kubernetes |
 |------------|-------|------------|
+| 1.0.14     | 2.7.2 | 1.8        |
+| 1.0.13     | 2.7.2 | 1.8        |
 | 1.0.12     | 2.7.2 | 1.8        |
 | 1.0.11     | 2.6.1 | 1.7        |
 | 1.0.10     | 2.5.1 | 1.6        |

--- a/pkg/landscaper/component.go
+++ b/pkg/landscaper/component.go
@@ -15,7 +15,7 @@ type Component struct {
 	Configuration Configuration  `json:"configuration"`
 	Environments  Configurations `json:"environments"`
 	SecretsRaw    interface{}    `json:"secrets"`
-	Secrets       Secrets        `json:"-"`
+	SecretNames   SecretNames    `json:"-"`
 	SecretValues  SecretValues   `json:"-"`
 }
 
@@ -23,13 +23,13 @@ type Component struct {
 type Components map[string]*Component
 
 // NewComponent creates a Component and adds Name to the configuration
-func NewComponent(name string, namespace string, release *Release, cfg Configuration, envs Configurations, secrets Secrets) *Component {
+func NewComponent(name string, namespace string, release *Release, cfg Configuration, envs Configurations, secretNames SecretNames) *Component {
 	cmp := &Component{
 		Name:          name,
 		Release:       release,
 		Configuration: cfg,
 		Environments:  envs,
-		Secrets:       secrets,
+		SecretNames:   secretNames,
 		SecretValues:  SecretValues{},
 		Namespace:     namespace,
 	}
@@ -42,8 +42,8 @@ func NewComponent(name string, namespace string, release *Release, cfg Configura
 		cmp.Environments = Configurations{}
 	}
 
-	if cmp.Secrets == nil {
-		cmp.Secrets = Secrets{}
+	if cmp.SecretNames == nil {
+		cmp.SecretNames = SecretNames{}
 	}
 
 	m := &Metadata{}
@@ -63,7 +63,13 @@ func (c *Component) Validate() error {
 
 // Equals checks if this component's values are equal to another
 func (c *Component) Equals(other *Component) bool {
-	return reflect.DeepEqual(c, other)
+	otherCopy := new(Component)
+	*otherCopy = *other
+
+	// Don't compare the SecretNames because we don't rebuild them from the cluster.
+	otherCopy.SecretNames = c.SecretNames
+
+	return reflect.DeepEqual(c, otherCopy)
 }
 
 // validateComponents validates the individual components as well as duplicate names in the total collection

--- a/pkg/landscaper/component.go
+++ b/pkg/landscaper/component.go
@@ -14,7 +14,8 @@ type Component struct {
 	Release       *Release       `json:"release" validate:"nonzero"`
 	Configuration Configuration  `json:"configuration"`
 	Environments  Configurations `json:"environments"`
-	Secrets       Secrets        `json:"secrets"`
+	SecretsRaw    interface{}    `json:"secrets"`
+	Secrets       Secrets        `json:"-"`
 	SecretValues  SecretValues   `json:"-"`
 }
 

--- a/pkg/landscaper/component_test.go
+++ b/pkg/landscaper/component_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func makeTestComp() *Component {
-	return NewComponent("name", "someNameSpace", &Release{"cha", "1.1.1"}, map[string]interface{}{"config": "awesome"}, Configurations{}, Secrets{"DIGG": "09F911029D74E35BD84156C5635688C0"})
+	return NewComponent("name", "someNameSpace", &Release{"cha", "1.1.1"}, map[string]interface{}{"config": "awesome"}, Configurations{}, SecretNames{"DIGG": "09F911029D74E35BD84156C5635688C0"})
 }
 
 func TestComponentNew(t *testing.T) {
@@ -18,7 +18,7 @@ func TestComponentNew(t *testing.T) {
 		&Release{"cha", "1.1.1"},
 		map[string]interface{}{"config": "awesome"},
 		Configurations{},
-		Secrets{"DIGG": "09F911029D74E35BD84156C5635688C0"},
+		SecretNames{"DIGG": "09F911029D74E35BD84156C5635688C0"},
 	)
 
 	cExp := &Component{
@@ -27,7 +27,7 @@ func TestComponentNew(t *testing.T) {
 		Release:       &Release{"cha", "1.1.1"},
 		Configuration: map[string]interface{}{"config": "awesome"},
 		Environments:  Configurations{},
-		Secrets:       Secrets{"DIGG": "09F911029D74E35BD84156C5635688C0"},
+		SecretNames:   SecretNames{"DIGG": "09F911029D74E35BD84156C5635688C0"},
 		SecretValues:  SecretValues{},
 	}
 	cExp.Configuration[metadataKey] = map[string]interface{}{
@@ -60,8 +60,8 @@ func TestComponentValidate(t *testing.T) {
 }
 
 func TestComponentEquals(t *testing.T) {
-	c0 := NewComponent("name", "default", &Release{"cha", "1.1.1"}, map[string]interface{}{"config": "awesome"}, Configurations{}, Secrets{"DIGG": "09F911029D74E35BD84156C5635688C0"})
-	c1 := NewComponent("name", "default", &Release{"cha", "1.1.1"}, map[string]interface{}{"config": "awesome"}, Configurations{}, Secrets{"DIGG": "09F911029D74E35BD84156C5635688C0"})
+	c0 := NewComponent("name", "default", &Release{"cha", "1.1.1"}, map[string]interface{}{"config": "awesome"}, Configurations{}, SecretNames{"DIGG": "09F911029D74E35BD84156C5635688C0"})
+	c1 := NewComponent("name", "default", &Release{"cha", "1.1.1"}, map[string]interface{}{"config": "awesome"}, Configurations{}, SecretNames{"DIGG": "09F911029D74E35BD84156C5635688C0"})
 	require.True(t, c0.Equals(c1))
 	c1.Name = "other"
 	require.False(t, c0.Equals(c1))

--- a/pkg/landscaper/component_test.go
+++ b/pkg/landscaper/component_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func makeTestComp() *Component {
-	return NewComponent("name", "someNameSpace", &Release{"cha", "1.1.1"}, map[string]interface{}{"config": "awesome"}, Configurations{}, Secrets{"09F911029D74E35BD84156C5635688C0"})
+	return NewComponent("name", "someNameSpace", &Release{"cha", "1.1.1"}, map[string]interface{}{"config": "awesome"}, Configurations{}, Secrets{"DIGG": "09F911029D74E35BD84156C5635688C0"})
 }
 
 func TestComponentNew(t *testing.T) {
@@ -18,7 +18,7 @@ func TestComponentNew(t *testing.T) {
 		&Release{"cha", "1.1.1"},
 		map[string]interface{}{"config": "awesome"},
 		Configurations{},
-		Secrets{"09F911029D74E35BD84156C5635688C0"},
+		Secrets{"DIGG": "09F911029D74E35BD84156C5635688C0"},
 	)
 
 	cExp := &Component{
@@ -27,7 +27,7 @@ func TestComponentNew(t *testing.T) {
 		Release:       &Release{"cha", "1.1.1"},
 		Configuration: map[string]interface{}{"config": "awesome"},
 		Environments:  Configurations{},
-		Secrets:       Secrets{"09F911029D74E35BD84156C5635688C0"},
+		Secrets:       Secrets{"DIGG": "09F911029D74E35BD84156C5635688C0"},
 		SecretValues:  SecretValues{},
 	}
 	cExp.Configuration[metadataKey] = map[string]interface{}{
@@ -60,8 +60,8 @@ func TestComponentValidate(t *testing.T) {
 }
 
 func TestComponentEquals(t *testing.T) {
-	c0 := NewComponent("name", "default", &Release{"cha", "1.1.1"}, map[string]interface{}{"config": "awesome"}, Configurations{}, Secrets{"09F911029D74E35BD84156C5635688C0"})
-	c1 := NewComponent("name", "default", &Release{"cha", "1.1.1"}, map[string]interface{}{"config": "awesome"}, Configurations{}, Secrets{"09F911029D74E35BD84156C5635688C0"})
+	c0 := NewComponent("name", "default", &Release{"cha", "1.1.1"}, map[string]interface{}{"config": "awesome"}, Configurations{}, Secrets{"DIGG": "09F911029D74E35BD84156C5635688C0"})
+	c1 := NewComponent("name", "default", &Release{"cha", "1.1.1"}, map[string]interface{}{"config": "awesome"}, Configurations{}, Secrets{"DIGG": "09F911029D74E35BD84156C5635688C0"})
 	require.True(t, c0.Equals(c1))
 	c1.Name = "other"
 	require.False(t, c0.Equals(c1))

--- a/pkg/landscaper/configuration.go
+++ b/pkg/landscaper/configuration.go
@@ -9,6 +9,7 @@ import (
 // Configuration contains all the values that should be applied to the component's helm package release
 type Configuration map[string]interface{}
 
+// Configurations are a list of environment specific configuration overrides
 type Configurations map[string]Configuration
 
 // YAML encodes the Values into a YAML string.
@@ -43,11 +44,12 @@ func (cfg Configuration) SetMetadata(m *Metadata) {
 	}
 }
 
-func (dest Configuration) Merge(src Configuration) Configuration {
-	return mergeValues(dest, src)
+// Merge two configurations
+func (cfg Configuration) Merge(src Configuration) Configuration {
+	return mergeValues(cfg, src)
 }
 
-func mergeValues(dest, src Configuration) (Configuration) {
+func mergeValues(dest, src Configuration) Configuration {
 	for k, v := range src {
 
 		// If the key doesn't exist already, then just set the key to that value
@@ -79,4 +81,3 @@ func mergeValues(dest, src Configuration) (Configuration) {
 	}
 	return dest
 }
-

--- a/pkg/landscaper/executor.go
+++ b/pkg/landscaper/executor.go
@@ -155,7 +155,7 @@ func (e *executor) CreateComponent(cmp *Component) error {
 		"dryrun":    e.dryRun,
 	}).Debug("Create component")
 
-	if len(cmp.Secrets) > 0 && !e.dryRun {
+	if len(cmp.SecretValues) > 0 && !e.dryRun {
 		err = e.kubeSecrets.Write(cmp.Name, cmp.Namespace, cmp.SecretValues)
 		if err != nil {
 			return err
@@ -198,11 +198,11 @@ func (e *executor) UpdateComponent(cmp *Component) error {
 	}
 
 	if !e.dryRun {
-		if e.stageEnabled("deleteSecrets") || len(cmp.Secrets) > 0 {
+		if e.stageEnabled("deleteSecrets") || len(cmp.SecretValues) > 0 {
 			err = e.kubeSecrets.Delete(cmp.Name, cmp.Namespace)
 		}
 
-		if len(cmp.Secrets) > 0 {
+		if len(cmp.SecretValues) > 0 {
 			err = e.kubeSecrets.Write(cmp.Name, cmp.Namespace, cmp.SecretValues)
 			if err != nil {
 				return err
@@ -241,7 +241,7 @@ func (e *executor) DeleteComponent(cmp *Component) error {
 		"dryrun":  e.dryRun,
 	}).Debug("Delete component")
 
-	if len(cmp.Secrets) > 0 && !e.dryRun {
+	if len(cmp.SecretValues) > 0 && !e.dryRun {
 		err := e.kubeSecrets.Delete(cmp.Name, cmp.Namespace)
 		if err != nil {
 			return err

--- a/pkg/landscaper/executor_test.go
+++ b/pkg/landscaper/executor_test.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/helm/pkg/proto/hapi/services"
 
 	"errors"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -278,7 +279,7 @@ func newTestComponent(name string) *Component {
 			"FilenameOffsetZeroPadWidth": 1,
 		},
 		Configurations{},
-		Secrets{"TestSecret1", "TestSecret2"},
+		Secrets{"TestSecret1": "TestSecret1", "TestSecret2": "TestSecret2"},
 	)
 
 	cmp.SecretValues = SecretValues{

--- a/pkg/landscaper/executor_test.go
+++ b/pkg/landscaper/executor_test.go
@@ -279,7 +279,7 @@ func newTestComponent(name string) *Component {
 			"FilenameOffsetZeroPadWidth": 1,
 		},
 		Configurations{},
-		Secrets{"TestSecret1": "TestSecret1", "TestSecret2": "TestSecret2"},
+		SecretNames{"TestSecret1": "TestSecret1", "TestSecret2": "TestSecret2"},
 	)
 
 	cmp.SecretValues = SecretValues{

--- a/pkg/landscaper/mocks_test.go
+++ b/pkg/landscaper/mocks_test.go
@@ -67,7 +67,7 @@ func (m MockChartLoader) Load(chartRef string) (*chart.Chart, string, error) { r
 
 type SecretsProviderMock struct {
 	write  func(releaseName, namespace string, values SecretValues) error
-	read   func(releaseName, namespace string, secretNames []string) (SecretValues, error)
+	read   func(releaseName, namespace string, secretNames map[string]string) (SecretValues, error)
 	delete func(releaseName, namespace string) error
 }
 
@@ -75,7 +75,7 @@ func (m SecretsProviderMock) Write(releaseName, namespace string, values SecretV
 	return m.write(releaseName, namespace, values)
 }
 
-func (m SecretsProviderMock) Read(releaseName, namespace string, secretNames []string) (SecretValues, error) {
+func (m SecretsProviderMock) Read(releaseName, namespace string, secretNames map[string]string) (SecretValues, error) {
 	return m.read(releaseName, namespace, secretNames)
 }
 

--- a/pkg/landscaper/mocks_test.go
+++ b/pkg/landscaper/mocks_test.go
@@ -67,7 +67,7 @@ func (m MockChartLoader) Load(chartRef string) (*chart.Chart, string, error) { r
 
 type SecretsProviderMock struct {
 	write  func(releaseName, namespace string, values SecretValues) error
-	read   func(releaseName, namespace string, secretNames map[string]string) (SecretValues, error)
+	read   func(releaseName, namespace string, secretNames SecretNames) (SecretValues, error)
 	delete func(releaseName, namespace string) error
 }
 
@@ -75,7 +75,7 @@ func (m SecretsProviderMock) Write(releaseName, namespace string, values SecretV
 	return m.write(releaseName, namespace, values)
 }
 
-func (m SecretsProviderMock) Read(releaseName, namespace string, secretNames map[string]string) (SecretValues, error) {
+func (m SecretsProviderMock) Read(releaseName, namespace string, secretNames SecretNames) (SecretValues, error) {
 	return m.read(releaseName, namespace, secretNames)
 }
 

--- a/pkg/landscaper/secrets.go
+++ b/pkg/landscaper/secrets.go
@@ -13,9 +13,9 @@ import (
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 )
 
-// Secrets is a map containing the name of the secrets and a reference to get their value from the
+// SecretNames is a map containing the name of the secrets and a reference to get their value from the
 // secrets provider.
-type Secrets map[string]string
+type SecretNames map[string]string
 
 // SecretValues is a map containing the actual values of the secrets. Note that this should not be written
 // to kubernetes or anywhere else persistent!
@@ -23,7 +23,7 @@ type SecretValues map[string][]byte
 
 // SecretsReader allows reading secrets
 type SecretsReader interface {
-	Read(componentName, namespace string, secretNames map[string]string) (SecretValues, error)
+	Read(componentName, namespace string, secretNames SecretNames) (SecretValues, error)
 }
 
 // SecretsWriteDeleter allows writing and deleting secrets
@@ -55,7 +55,7 @@ func NewEnvironmentSecretsReader() SecretsReader {
 }
 
 // Read reads all secrets in the k8s secret object. It ignores secretNames.
-func (sp *kubeSecretsProvider) Read(componentName, namespace string, secretNames map[string]string) (SecretValues, error) {
+func (sp *kubeSecretsProvider) Read(componentName, namespace string, secretNames SecretNames) (SecretValues, error) {
 	logrus.WithFields(logrus.Fields{"component": componentName, "namespace": namespace}).Debug("Reading secrets for component")
 
 	secrets := SecretValues{}
@@ -157,7 +157,7 @@ func (sp *kubeSecretsProvider) ensureNamespace(namespace string) error {
 }
 
 // Read reads the given secretNames from the environment, by uppercasing the name and converting - into _. componentName and namespace are ignored
-func (env *environmentSecrets) Read(componentName, namespace string, secretNames map[string]string) (SecretValues, error) {
+func (env *environmentSecrets) Read(componentName, namespace string, secretNames SecretNames) (SecretValues, error) {
 	secs := SecretValues{}
 	for key, value := range secretNames {
 		envName := strings.Replace(strings.ToUpper(value), "-", "_", -1)

--- a/pkg/landscaper/secrets.go
+++ b/pkg/landscaper/secrets.go
@@ -13,8 +13,9 @@ import (
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 )
 
-// Secrets is currently a slice of secret names that should be applied to a component
-type Secrets []string
+// Secrets is a map containing the name of the secrets and a reference to get their value from the
+// secrets provider.
+type Secrets map[string]string
 
 // SecretValues is a map containing the actual values of the secrets. Note that this should not be written
 // to kubernetes or anywhere else persistent!
@@ -22,7 +23,7 @@ type SecretValues map[string][]byte
 
 // SecretsReader allows reading secrets
 type SecretsReader interface {
-	Read(componentName, namespace string, secretNames []string) (SecretValues, error)
+	Read(componentName, namespace string, secretNames map[string]string) (SecretValues, error)
 }
 
 // SecretsWriteDeleter allows writing and deleting secrets
@@ -49,12 +50,12 @@ func NewKubeSecretsReadWriteDeleter(kubeClient internalversion.CoreInterface) Se
 }
 
 // NewEnvironmentSecretsReader creates a SecretsReader for secrets provided via environment variables
-func NewEnvironmentSecretsReader() (SecretsReader) {
+func NewEnvironmentSecretsReader() SecretsReader {
 	return &environmentSecrets{}
 }
 
 // Read reads all secrets in the k8s secret object. It ignores secretNames.
-func (sp *kubeSecretsProvider) Read(componentName, namespace string, secretNames []string) (SecretValues, error) {
+func (sp *kubeSecretsProvider) Read(componentName, namespace string, secretNames map[string]string) (SecretValues, error) {
 	logrus.WithFields(logrus.Fields{"component": componentName, "namespace": namespace}).Debug("Reading secrets for component")
 
 	secrets := SecretValues{}
@@ -156,10 +157,10 @@ func (sp *kubeSecretsProvider) ensureNamespace(namespace string) error {
 }
 
 // Read reads the given secretNames from the environment, by uppercasing the name and converting - into _. componentName and namespace are ignored
-func (env *environmentSecrets) Read(componentName, namespace string, secretNames []string) (SecretValues, error) {
+func (env *environmentSecrets) Read(componentName, namespace string, secretNames map[string]string) (SecretValues, error) {
 	secs := SecretValues{}
-	for _, key := range secretNames {
-		envName := strings.Replace(strings.ToUpper(key), "-", "_", -1)
+	for key, value := range secretNames {
+		envName := strings.Replace(strings.ToUpper(value), "-", "_", -1)
 
 		secretValue := os.Getenv(envName)
 		if len(secretValue) == 0 {

--- a/pkg/landscaper/secrets_azure.go
+++ b/pkg/landscaper/secrets_azure.go
@@ -54,7 +54,7 @@ func NewAzureSecretsReader(keyVault string) (SecretsReader, error) {
 }
 
 // Reads the secret from the Azure key vault
-func (asp *azureSecretsReader) Read(componentName, namespace string, secretNames map[string]string) (SecretValues, error) {
+func (asp *azureSecretsReader) Read(componentName, namespace string, secretNames SecretNames) (SecretValues, error) {
 	logrus.WithFields(logrus.Fields{"component": componentName, "namespace": namespace}).Debug("Reading secrets for component")
 
 	secrets := SecretValues{}

--- a/pkg/landscaper/state_provider_test.go
+++ b/pkg/landscaper/state_provider_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestFileStateProviderComponents(t *testing.T) {
 	secretsMock := SecretsProviderMock{
-		read: func(componentName, namespace string, secretNames map[string]string) (SecretValues, error) {
+		read: func(componentName, namespace string, secretNames SecretNames) (SecretValues, error) {
 			t.Logf("secretsMock read %#v %#v %#v", componentName, namespace, secretNames)
 			vs := SecretValues{}
 			for k, s := range secretNames {
@@ -72,7 +72,7 @@ ref: %s
 		require.Equal(t, "local/hello-secret:1.3.37", c1.Configuration["ref"]) //unspecified in file, obtained from chart
 		require.Equal(t, "local/hello-secret:0.1.0", c2.Configuration["ref"])
 
-		require.Len(t, c1.Secrets, 0) // Secret names are removed, only the values map is kept
+		require.Len(t, c1.SecretNames, 2)
 
 		require.Len(t, c1.SecretValues, 2)
 		require.Equal(t, []byte("pfx-secretivenewnamh3llo-nam3"), c1.SecretValues["hello-name"])
@@ -82,7 +82,7 @@ ref: %s
 
 func TestOptionalVersion(t *testing.T) {
 	secretsMock := SecretsProviderMock{
-		read: func(componentName, namespace string, secretNames map[string]string) (SecretValues, error) {
+		read: func(componentName, namespace string, secretNames SecretNames) (SecretValues, error) {
 			t.Logf("secretsMock read %#v %#v %#v", componentName, namespace, secretNames)
 			vs := SecretValues{}
 			for k, s := range secretNames {
@@ -149,7 +149,7 @@ config_c: qqq
 		},
 	}
 	secretsMock := SecretsProviderMock{
-		read: func(componentName, namespace string, secretNames map[string]string) (SecretValues, error) {
+		read: func(componentName, namespace string, secretNames SecretNames) (SecretValues, error) {
 			t.Logf("secretsMock read %#v %#v %#v", componentName, namespace, secretNames)
 			return nil, nil
 		},
@@ -170,7 +170,7 @@ config_c: qqq
 
 func TestMultipleEnvironments(t *testing.T) {
 	secretsMock := SecretsProviderMock{
-		read: func(componentName, namespace string, secretNames map[string]string) (SecretValues, error) {
+		read: func(componentName, namespace string, secretNames SecretNames) (SecretValues, error) {
 			t.Logf("secretsMock read %#v %#v %#v", componentName, namespace, secretNames)
 			vs := SecretValues{}
 			for k, s := range secretNames {
@@ -239,7 +239,7 @@ ref: %s
 
 func TestSecretLoaders(t *testing.T) {
 	secretsMock := SecretsProviderMock{
-		read: func(componentName, namespace string, secretNames map[string]string) (SecretValues, error) {
+		read: func(componentName, namespace string, secretNames SecretNames) (SecretValues, error) {
 			t.Logf("secretsMock read %#v %#v %#v", componentName, namespace, secretNames)
 			vs := SecretValues{}
 			for k, s := range secretNames {

--- a/test/landscapes/secrets/secret-list.yaml
+++ b/test/landscapes/secrets/secret-list.yaml
@@ -1,0 +1,9 @@
+name: secret-list
+release:
+  chart: local/list-secrets:0.1.0
+  version: 0.1.0
+configuration:
+  message: These secrets are searched by name!
+secrets:
+  - list-secret-one
+  - list-secret-two

--- a/test/landscapes/secrets/secret-map.yaml
+++ b/test/landscapes/secrets/secret-map.yaml
@@ -1,0 +1,9 @@
+name: secret-map
+release:
+  chart: local/map-secrets:0.2.0
+  version: 0.2.0
+configuration:
+  message: These secrets are searched by value!
+secrets:
+  map-secret-one: look-here-one
+  map-secret-two: look-here-two

--- a/test/landscapes/secrets/secret-none.yaml
+++ b/test/landscapes/secrets/secret-none.yaml
@@ -1,0 +1,6 @@
+name: secret-none
+release:
+  chart: local/map-secrets:0.2.0
+  version: 0.2.0
+configuration:
+  message: There are no secrets!


### PR DESCRIPTION
This feature makes it easier to deal with charts or containers that expect specific keys in secret objects. For example an nginx ingress controller expects basic auth credentials to be `auth: <list of htpasswds>`.

The unmarshalling of the secret list/map is done manually, and the `Secret` and `SecretsRaw` fields are cleaned after the `SecretValues` are fetched so that they are ignored by the compare.