### PR TITLE
Add Helm 2.8.2 support

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,14 +2,6 @@
 
 
 [[projects]]
-  name = "cloud.google.com/go"
-  packages = [
-    "compute/metadata",
-    "internal"
-  ]
-  revision = "3b1ae45394a234c385be014e9a488f2bb6eef821"
-
-[[projects]]
   name = "github.com/Azure/azure-sdk-for-go"
   packages = [
     "arm/examples/helpers",
@@ -68,48 +60,6 @@
   name = "github.com/PuerkitoBio/urlesc"
   packages = ["."]
   revision = "5bd2802263f21d8788851d5305584c82a5c75d7e"
-
-[[projects]]
-  name = "github.com/aws/aws-sdk-go"
-  packages = [
-    "aws",
-    "aws/awserr",
-    "aws/awsutil",
-    "aws/client",
-    "aws/client/metadata",
-    "aws/corehandlers",
-    "aws/credentials",
-    "aws/credentials/ec2rolecreds",
-    "aws/credentials/endpointcreds",
-    "aws/credentials/stscreds",
-    "aws/csm",
-    "aws/defaults",
-    "aws/ec2metadata",
-    "aws/endpoints",
-    "aws/request",
-    "aws/session",
-    "aws/signer/v4",
-    "internal/sdkio",
-    "internal/sdkrand",
-    "internal/shareddefaults",
-    "private/protocol",
-    "private/protocol/ec2query",
-    "private/protocol/json/jsonutil",
-    "private/protocol/jsonrpc",
-    "private/protocol/query",
-    "private/protocol/query/queryutil",
-    "private/protocol/rest",
-    "private/protocol/xml/xmlutil",
-    "service/autoscaling",
-    "service/ec2",
-    "service/ecr",
-    "service/elb",
-    "service/elbv2",
-    "service/kms",
-    "service/sts"
-  ]
-  revision = "47309c012812d9e9c488a54313e5cdfa7479df93"
-  version = "v1.14.1"
 
 [[projects]]
   name = "github.com/beorn7/perks"
@@ -173,14 +123,6 @@
   revision = "449fdfce4d962303d702fec724ef0ad181c92528"
 
 [[projects]]
-  name = "github.com/emicklei/go-restful"
-  packages = [
-    ".",
-    "log"
-  ]
-  revision = "09691a3b6378b740595c1002f40c34dd5f218a22"
-
-[[projects]]
   branch = "master"
   name = "github.com/evanphx/json-patch"
   packages = ["."]
@@ -202,12 +144,6 @@
   packages = ["."]
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
   version = "v1.0.0"
-
-[[projects]]
-  name = "github.com/go-ini/ini"
-  packages = ["."]
-  revision = "06f5f3d67269ccec1fe5fe4134ba6e982984f7f5"
-  version = "v1.37.0"
 
 [[projects]]
   name = "github.com/go-openapi/jsonpointer"
@@ -294,19 +230,6 @@
   revision = "0c5108395e2debce0d731cf0287ddf7242066aba"
 
 [[projects]]
-  name = "github.com/gophercloud/gophercloud"
-  packages = [
-    ".",
-    "openstack",
-    "openstack/identity/v2/tenants",
-    "openstack/identity/v2/tokens",
-    "openstack/identity/v3/tokens",
-    "openstack/utils",
-    "pagination"
-  ]
-  revision = "2bf16b94fdd9b01557c4d076e567fe5cbbe5a961"
-
-[[projects]]
   name = "github.com/gregjones/httpcache"
   packages = [
     ".",
@@ -340,20 +263,9 @@
   version = "v1.0"
 
 [[projects]]
-  name = "github.com/jmespath/go-jmespath"
-  packages = ["."]
-  revision = "0b12d6b5"
-
-[[projects]]
   name = "github.com/json-iterator/go"
   packages = ["."]
-  revision = "36b14963da70d11297d313183d7e6388c8510e1e"
-  version = "1.0.0"
-
-[[projects]]
-  name = "github.com/juju/ratelimit"
-  packages = ["."]
-  revision = "5b9ff866471762aa2ab2dced63c9fb6f53921342"
+  revision = "f2b4162afba35581b6d4a50d3b8f34e33c144682"
 
 [[projects]]
   name = "github.com/mailru/easyjson"
@@ -391,6 +303,18 @@
   name = "github.com/mitchellh/go-wordwrap"
   packages = ["."]
   revision = "ad45545899c7b13c020ea92b2072220eefad42b8"
+
+[[projects]]
+  name = "github.com/modern-go/concurrent"
+  packages = ["."]
+  revision = "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"
+  version = "1.0.3"
+
+[[projects]]
+  name = "github.com/modern-go/reflect2"
+  packages = ["."]
+  revision = "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd"
+  version = "1.0.1"
 
 [[projects]]
   name = "github.com/opencontainers/go-digest"
@@ -497,6 +421,8 @@
   name = "golang.org/x/crypto"
   packages = [
     "cast5",
+    "ed25519",
+    "ed25519/internal/edwards25519",
     "openpgp",
     "openpgp/armor",
     "openpgp/clearsign",
@@ -504,6 +430,7 @@
     "openpgp/errors",
     "openpgp/packet",
     "openpgp/s2k",
+    "pbkdf2",
     "ssh/terminal"
   ]
   revision = "94eea52f7b742c7cbe0b03b22f0c4c8631ece122"
@@ -512,7 +439,6 @@
   name = "golang.org/x/net"
   packages = [
     "context",
-    "context/ctxhttp",
     "http2",
     "http2/hpack",
     "idna",
@@ -521,17 +447,6 @@
     "trace"
   ]
   revision = "dc871a5d77e227f5bbf6545176ef3eeebf87e76e"
-
-[[projects]]
-  name = "golang.org/x/oauth2"
-  packages = [
-    ".",
-    "google",
-    "internal",
-    "jws",
-    "jwt"
-  ]
-  revision = "a6bd8cefa1811bd24b86f8902872e4e8225f74c4"
 
 [[projects]]
   name = "golang.org/x/sys"
@@ -572,20 +487,10 @@
   revision = "3b24cac7bc3a458991ab409aa2a339ac9e0d60d6"
 
 [[projects]]
-  name = "google.golang.org/appengine"
-  packages = [
-    ".",
-    "internal",
-    "internal/app_identity",
-    "internal/base",
-    "internal/datastore",
-    "internal/log",
-    "internal/modules",
-    "internal/remote_api",
-    "internal/urlfetch",
-    "urlfetch"
-  ]
-  revision = "9d8544a6b2c7df9cff240fcf92d7b2f59bc13416"
+  branch = "master"
+  name = "golang.org/x/time"
+  packages = ["rate"]
+  revision = "fbb02b2291d28baffd63558aa44b4b56f178d650"
 
 [[projects]]
   name = "google.golang.org/genproto"
@@ -617,17 +522,6 @@
   revision = "5ffe3083946d5603a0578721101dc8165b1d5b5f"
 
 [[projects]]
-  name = "gopkg.in/gcfg.v1"
-  packages = [
-    ".",
-    "scanner",
-    "token",
-    "types"
-  ]
-  revision = "61b2c08bc8f6068f7c5ca684372f9a6cb1c45ebe"
-  version = "v1.2.3"
-
-[[projects]]
   name = "gopkg.in/inf.v0"
   packages = ["."]
   revision = "3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4"
@@ -640,16 +534,21 @@
   revision = "eb84b840d3d6889d2458ceed28e3c6f0d109f6c8"
 
 [[projects]]
+  name = "gopkg.in/square/go-jose.v2"
+  packages = [
+    ".",
+    "cipher",
+    "json",
+    "jwt"
+  ]
+  revision = "8254d6c783765f38c8675fae4427a1fe73fbd09d"
+  version = "v2.1.8"
+
+[[projects]]
   branch = "v2"
   name = "gopkg.in/validator.v2"
   packages = ["."]
   revision = "460c83432a98c35224a6fe352acf8b23e067ad06"
-
-[[projects]]
-  name = "gopkg.in/warnings.v0"
-  packages = ["."]
-  revision = "ec4a0fea49c7b46c2aeb0b51aac55779c607e52b"
-  version = "v0.1.2"
 
 [[projects]]
   name = "gopkg.in/yaml.v2"
@@ -690,13 +589,12 @@
     "storage/v1alpha1",
     "storage/v1beta1"
   ]
-  revision = "006a217681ae70cbacdd66a5e2fca1a61a8ff28e"
-  version = "kubernetes-1.9.1"
+  revision = "8b7507fac302640dd5f1efbf9643199952cc58db"
 
 [[projects]]
   name = "k8s.io/apiextensions-apiserver"
   packages = ["pkg/features"]
-  revision = "099fd227da1f60394aac19c77254374142d01079"
+  revision = "898b0eda132e1aeac43a459785144ee4bf9b0a2e"
 
 [[projects]]
   name = "k8s.io/apimachinery"
@@ -713,7 +611,7 @@
     "pkg/apis/meta/v1",
     "pkg/apis/meta/v1/unstructured",
     "pkg/apis/meta/v1/validation",
-    "pkg/apis/meta/v1alpha1",
+    "pkg/apis/meta/v1beta1",
     "pkg/conversion",
     "pkg/conversion/queryparams",
     "pkg/fields",
@@ -731,6 +629,7 @@
     "pkg/util/cache",
     "pkg/util/clock",
     "pkg/util/diff",
+    "pkg/util/duration",
     "pkg/util/errors",
     "pkg/util/framer",
     "pkg/util/httpstream",
@@ -755,8 +654,7 @@
     "third_party/forked/golang/netutil",
     "third_party/forked/golang/reflect"
   ]
-  revision = "68f9c3a1feb3140df59c67ced62d3a5df8e6c9c2"
-  version = "kubernetes-1.9.1"
+  revision = "f6313580a4d36c7c74a3d845dda6e116642c4f90"
 
 [[projects]]
   name = "k8s.io/apiserver"
@@ -770,8 +668,7 @@
     "pkg/util/feature",
     "pkg/util/flag"
   ]
-  revision = "2a1092aaa7202e8f9b188281ff9424a014ce61c2"
-  version = "kubernetes-1.9.2"
+  revision = "f7914ed3085badf66a1b6f3a5218ada28f7bd084"
 
 [[projects]]
   name = "k8s.io/client-go"
@@ -872,14 +769,20 @@
     "listers/storage/v1",
     "listers/storage/v1alpha1",
     "listers/storage/v1beta1",
+    "pkg/apis/clientauthentication",
+    "pkg/apis/clientauthentication/v1alpha1",
     "pkg/version",
-    "plugin/pkg/client/auth",
-    "plugin/pkg/client/auth/azure",
-    "plugin/pkg/client/auth/gcp",
-    "plugin/pkg/client/auth/oidc",
-    "plugin/pkg/client/auth/openstack",
+    "plugin/pkg/client/auth/exec",
     "rest",
     "rest/watch",
+    "scale",
+    "scale/scheme",
+    "scale/scheme/appsint",
+    "scale/scheme/appsv1beta1",
+    "scale/scheme/appsv1beta2",
+    "scale/scheme/autoscalingv1",
+    "scale/scheme/extensionsint",
+    "scale/scheme/extensionsv1beta1",
     "third_party/forked/golang/template",
     "tools/auth",
     "tools/cache",
@@ -905,8 +808,7 @@
     "util/retry",
     "util/workqueue"
   ]
-  revision = "9389c055a838d4f208b699b3c7c51b70f2368861"
-  version = "kubernetes-1.9.1"
+  revision = "23781f4d6632d88e869066eaebb743857aa1ef9b"
 
 [[projects]]
   name = "k8s.io/helm"
@@ -927,22 +829,22 @@
     "pkg/provenance",
     "pkg/repo",
     "pkg/resolver",
+    "pkg/storage/driver",
     "pkg/sympath",
     "pkg/tlsutil",
     "pkg/urlutil",
     "pkg/version"
   ]
-  revision = "a80231648a1473929271764b920a8e346f6de844"
-  version = "v2.8.2"
+  revision = "9ad53aac42165a5fadc6c87be0dea6b115f93090"
+  version = "v2.10.0"
 
 [[projects]]
   name = "k8s.io/kube-openapi"
   packages = [
-    "pkg/common",
     "pkg/util/proto",
     "pkg/util/proto/validation"
   ]
-  revision = "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+  revision = "39cb288412c48cb533ba4be5d6c28620b9a0c1b4"
 
 [[projects]]
   name = "k8s.io/kubernetes"
@@ -954,7 +856,6 @@
     "pkg/api/resource",
     "pkg/api/service",
     "pkg/api/v1/pod",
-    "pkg/api/v1/service",
     "pkg/apis/admissionregistration",
     "pkg/apis/admissionregistration/install",
     "pkg/apis/admissionregistration/v1alpha1",
@@ -1044,9 +945,7 @@
     "pkg/client/clientset_generated/internalclientset/typed/scheduling/internalversion",
     "pkg/client/clientset_generated/internalclientset/typed/settings/internalversion",
     "pkg/client/clientset_generated/internalclientset/typed/storage/internalversion",
-    "pkg/client/unversioned",
     "pkg/cloudprovider",
-    "pkg/cloudprovider/providers/aws",
     "pkg/controller",
     "pkg/controller/daemon",
     "pkg/controller/daemon/util",
@@ -1055,8 +954,8 @@
     "pkg/controller/statefulset",
     "pkg/controller/volume/events",
     "pkg/controller/volume/persistentvolume",
+    "pkg/controller/volume/persistentvolume/metrics",
     "pkg/credentialprovider",
-    "pkg/credentialprovider/aws",
     "pkg/features",
     "pkg/fieldpath",
     "pkg/kubectl",
@@ -1073,6 +972,7 @@
     "pkg/kubectl/util/hash",
     "pkg/kubectl/util/slice",
     "pkg/kubectl/util/term",
+    "pkg/kubectl/util/transport",
     "pkg/kubectl/validation",
     "pkg/kubelet/apis",
     "pkg/kubelet/types",
@@ -1080,6 +980,13 @@
     "pkg/printers",
     "pkg/printers/internalversion",
     "pkg/registry/rbac/validation",
+    "pkg/scheduler/algorithm",
+    "pkg/scheduler/algorithm/predicates",
+    "pkg/scheduler/algorithm/priorities/util",
+    "pkg/scheduler/api",
+    "pkg/scheduler/schedulercache",
+    "pkg/scheduler/util",
+    "pkg/scheduler/volumebinder",
     "pkg/security/apparmor",
     "pkg/serviceaccount",
     "pkg/util/file",
@@ -1101,21 +1008,16 @@
     "pkg/version",
     "pkg/volume",
     "pkg/volume/util",
-    "plugin/pkg/scheduler/algorithm",
-    "plugin/pkg/scheduler/algorithm/predicates",
-    "plugin/pkg/scheduler/algorithm/priorities/util",
-    "plugin/pkg/scheduler/api",
-    "plugin/pkg/scheduler/schedulercache",
-    "plugin/pkg/scheduler/util",
-    "plugin/pkg/scheduler/volumebinder"
+    "pkg/volume/util/fs",
+    "pkg/volume/util/recyclerclient",
+    "pkg/volume/util/types"
   ]
-  revision = "5fa2db2bd46ac79e5e00a4e6ed24191080aa463b"
-  version = "v1.9.2"
+  revision = "32ac1c9073b132b8ba18aa830f46b77dcceb0723"
 
 [[projects]]
   name = "k8s.io/utils"
   packages = ["exec"]
-  revision = "9fdc871a36f37980dd85f96d576b20d564cc0784"
+  revision = "aedf551cdb8b0119df3a19c65fde413a13b34997"
 
 [[projects]]
   branch = "master"
@@ -1126,6 +1028,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "fdc395b646427489d2e83113357c4557d227b353a5f8806694573071a7e906fe"
+  inputs-digest = "21f5f83d51ee3e5ec40e0e3a96229e8f1ed0df32ce65b8f62f0b3da7f3dd0295"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -22,7 +22,46 @@
 
 [[constraint]]
   name = "k8s.io/helm"
-  version = "=2.10.0"
+  version = "2.10.0"
+
+# Dependencies from Helm 2.10.0 glide.lock file
+# https://github.com/helm/helm/blob/v2.10.0/glide.lock
+[[override]]
+  name = "k8s.io/client-go"
+  revision = "23781f4d6632d88e869066eaebb743857aa1ef9b"
+
+[[override]]
+  name = "k8s.io/kubernetes"
+  revision = "32ac1c9073b132b8ba18aa830f46b77dcceb0723"
+
+[[override]]
+  name = "k8s.io/api"
+  revision = "8b7507fac302640dd5f1efbf9643199952cc58db"
+
+[[override]]
+  name = "k8s.io/apiextensions-apiserver"
+  revision = "898b0eda132e1aeac43a459785144ee4bf9b0a2e"
+
+[[override]]
+  name = "k8s.io/apiserver"
+  revision = "f7914ed3085badf66a1b6f3a5218ada28f7bd084"
+
+[[override]]
+  name = "k8s.io/apimachinery"
+  revision = "f6313580a4d36c7c74a3d845dda6e116642c4f90"
+
+[[override]]
+  name = "k8s.io/kube-openapi"
+  revision = "39cb288412c48cb533ba4be5d6c28620b9a0c1b4"
+
+[[override]]
+  name = "k8s.io/utils"
+  revision = "aedf551cdb8b0119df3a19c65fde413a13b34997"
+
+# unknown field 'CaseSensitive' in struct literal of type jsoniter.Config
+[[override]]
+  name = "github.com/json-iterator/go"
+  revision = "f2b4162afba35581b6d4a50d3b8f34e33c144682"
 
 # Fix google.org/protobuf
 # https://github.com/google/protobuf/issues/4582

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -22,7 +22,7 @@
 
 [[constraint]]
   name = "k8s.io/helm"
-  version = "=2.8.2"
+  version = "=2.10.0"
 
 # Fix google.org/protobuf
 # https://github.com/google/protobuf/issues/4582

--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ Landscaper uses both Helm and Kubernetes. The following Landscaper releases are 
 
 | Landscaper | Helm  | Kubernetes |
 |------------|-------|------------|
+| 1.0.19     | 2.10.0| 1.10       |
 | 1.0.17     | 2.8.2 | 1.9        |
 | 1.0.16     | 2.7.2 | 1.8        |
 | 1.0.15     | 2.7.2 | 1.8        |

--- a/pkg/landscaper/environment.go
+++ b/pkg/landscaper/environment.go
@@ -163,7 +163,7 @@ func teardown() {
 // getKubeClient is a convenience method for creating kubernetes config and client
 // for a given kubeconfig context
 func getKubeClient(context string) (*restclient.Config, *internalclientset.Clientset, error) {
-	config, err := kube.GetConfig(context).ClientConfig()
+	config, err := kube.GetConfig(context, "").ClientConfig()
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not get kubernetes config for context '%s': %s", context, err)
 	}


### PR DESCRIPTION
Updated constraint to allow Helm 2.10.0.

This prevents 
```
level=error msg="Loading current state failed" error=EOF 
Error: EOF
```
messages.