### PR TITLE
"Cherry pick" Helm fix for go panic Helm lists releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ Landscaper uses both Helm and Kubernetes. The following Landscaper releases are 
 
 | Landscaper | Helm  | Kubernetes |
 |------------|-------|------------|
+| 1.0.21     | 2.11.0| 1.11.1     |
 | 1.0.20     | 2.11.0| 1.11.1     |
 | 1.0.19     | 2.10.0| 1.10.3     |
 | 1.0.17     | 2.8.2 | 1.9        |

--- a/pkg/landscaper/state_provider.go
+++ b/pkg/landscaper/state_provider.go
@@ -321,7 +321,7 @@ func (cp *helmStateProvider) listHelmReleases() ([]*release.Release, error) {
 		return nil, err
 	}
 
-	return res.Releases, nil
+	return res.GetReleases(), nil
 }
 
 // newComponentFromHelmRelease creates a Component from a Release


### PR DESCRIPTION
Currently, Landscaper fails to list Helm releases throwing the following error

```
time="2018-09-26T15:00:38Z" level=debug msg=listHelmReleases
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x11f5d4e]

goroutine 1 [running]:
github.com/eneco/landscaper/pkg/landscaper.(*helmStateProvider).listHelmReleases(0xc420b2b530, 0x1, 0x1, 0x0, 0x0, 0x0)
	/root/go/src/github.com/eneco/landscaper/pkg/landscaper/state_provider.go:324 +0x18e
github.com/eneco/landscaper/pkg/landscaper.(*helmStateProvider).Components(0xc420b2b530, 0xc420b2b560, 0x0, 0x0)
...
```

A colleague found [this issue](https://github.com/helm/helm/issues/3625) on Helm repo and the related [merged PR](https://github.com/helm/helm/pull/4325)

I basically copy and paste their implementation :sweat_smile: 