### PR TITLE
Feature: Flags to opt-out forced updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,24 +70,26 @@ The `apply` command accepts the following arguments:
       landscaper apply [files]... [flags]
     
     Flags:
-          --azure-keyvault string         azure keyvault for fetching secrets. Azure credentials must be provided in the environment.
-          --chart-dir string              (deprecated; use --helm-home) Helm home directory (default "$HOME/.helm")
-          --config-override-file string   global configuration overrides. component specific environment overrides take precedence over this.
-          --context string                the kube context to use. defaults to the current context
-          --dir string                    (deprecated) path to a folder that contains all the landscape desired state files; overrides LANDSCAPE_DIR
-          --disable stringSlice           Stages to be disabled. Available stages are create/update/delete.
-          --dry-run                       simulate the applying of the landscape. useful in merge requests
-          --helm-home string              Helm home directory (default "$HOME/.helm")
-          --env string                    environment specifier. selects value overrides by environment.
-          --loop                          keep landscape in sync forever
-          --loop-interval duration        when running in a loop the interval between invocations (default 5m0s)
-          --namespace string              namespace to apply the landscape to; overrides LANDSCAPE_NAMESPACE (default "default")
-          --no-prefix                     disable prefixing release names
-          --prefix string                 prefix release names with this string instead of <namespace>; overrides LANDSCAPE_PREFIX
-          --tiller-namespace string       Tiller namespace for Helm (default "kube-system")
-      -v, --verbose                       be verbose
-          --wait                          wait for all resources to be ready
-          --wait-timeout duration         interval to wait for all resources to be ready (default 5m0s)
+          --azure-keyvault string            azure keyvault for fetching secrets. Azure credentials must be provided in the environment.
+          --chart-dir string                 (deprecated; use --helm-home) Helm home directory (default "$HOME/.helm")
+          --config-override-file string      global configuration overrides. component specific environment overrides take precedence over this.
+          --context string                   the kube context to use. defaults to the current context
+          --dir string                       (deprecated) path to a folder that contains all the landscape desired state files; overrides LANDSCAPE_DIR
+          --disable stringSlice              Stages to be disabled. Available stages are create/update/delete.
+          --disable-forced-updates           Disables forced updates completelly
+          --disable-secrets-forced-updates   Disables forced updates for secret changes only
+          --dry-run                          simulate the applying of the landscape. useful in merge requests
+          --helm-home string                 Helm home directory (default "$HOME/.helm")
+          --env string                       environment specifier. selects value overrides by environment.
+          --loop                             keep landscape in sync forever
+          --loop-interval duration           when running in a loop the interval between invocations (default 5m0s)
+          --namespace string                 namespace to apply the landscape to; overrides LANDSCAPE_NAMESPACE (default "default")
+          --no-prefix                        disable prefixing release names
+          --prefix string                    prefix release names with this string instead of <namespace>; overrides LANDSCAPE_PREFIX
+          --tiller-namespace string          Tiller namespace for Helm (default "kube-system")
+      -v, --verbose                          be verbose
+          --wait                             wait for all resources to be ready
+          --wait-timeout duration            interval to wait for all resources to be ready (default 5m0s)
 
 Instead of using arguments, environment variables can be used. When arguments are present, they override environment variables.
 `--namespace` is used to isolate landscapes through Kubernetes namespaces.
@@ -263,6 +265,7 @@ Landscaper uses both Helm and Kubernetes. The following Landscaper releases are 
 
 | Landscaper | Helm  | Kubernetes |
 |------------|-------|------------|
+| 1.0.22     | 2.11.0| 1.11.1     |
 | 1.0.21     | 2.11.0| 1.11.1     |
 | 1.0.20     | 2.11.0| 1.11.1     |
 | 1.0.19     | 2.10.0| 1.10.3     |

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The `apply` command accepts the following arguments:
           --context string                   the kube context to use. defaults to the current context
           --dir string                       (deprecated) path to a folder that contains all the landscape desired state files; overrides LANDSCAPE_DIR
           --disable stringSlice              Stages to be disabled. Available stages are create/update/delete.
-          --disable-forced-updates           Disables forced updates completelly
+          --disable-forced-updates           Disables forced updates completely
           --disable-secrets-forced-updates   Disables forced updates for secret changes only
           --dry-run                          simulate the applying of the landscape. useful in merge requests
           --helm-home string                 Helm home directory (default "$HOME/.helm")

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -119,6 +119,8 @@ func init() {
 	f.StringVar(&env.HelmHome, "helm-home", helmHome, "Helm home directory")
 	f.StringVar(&env.TillerNamespace, "tiller-namespace", tillerNamespace, "Tiller namespace for Helm")
 	f.Var(&env.DisabledStages, "disable", "Stages to be disabled. Available stages are create/update/delete.")
+	f.BoolVar(&env.DisabledForceUpdates, "disable-forced-updates", false, "Disables forced updates completally")
+	f.BoolVar(&env.DisabledSecretsForceUpdates, "disable-secrets-forced-updates", false, "Disables forced updates for secret changes only")
 
 	f.BoolVar(&env.Loop, "loop", false, "keep landscape in sync forever")
 	f.DurationVar(&env.LoopInterval, "loop-interval", 5*time.Minute, "when running in a loop the interval between invocations")

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -119,7 +119,7 @@ func init() {
 	f.StringVar(&env.HelmHome, "helm-home", helmHome, "Helm home directory")
 	f.StringVar(&env.TillerNamespace, "tiller-namespace", tillerNamespace, "Tiller namespace for Helm")
 	f.Var(&env.DisabledStages, "disable", "Stages to be disabled. Available stages are create/update/delete.")
-	f.BoolVar(&env.DisabledForcedUpdates, "disable-forced-updates", false, "Disables forced updates completally")
+	f.BoolVar(&env.DisabledForcedUpdates, "disable-forced-updates", false, "Disables forced updates completelly")
 	f.BoolVar(&env.DisabledSecretsForcedUpdates, "disable-secrets-forced-updates", false, "Disables forced updates for secret changes only")
 
 	f.BoolVar(&env.Loop, "loop", false, "keep landscape in sync forever")

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -119,8 +119,8 @@ func init() {
 	f.StringVar(&env.HelmHome, "helm-home", helmHome, "Helm home directory")
 	f.StringVar(&env.TillerNamespace, "tiller-namespace", tillerNamespace, "Tiller namespace for Helm")
 	f.Var(&env.DisabledStages, "disable", "Stages to be disabled. Available stages are create/update/delete.")
-	f.BoolVar(&env.DisabledForceUpdates, "disable-forced-updates", false, "Disables forced updates completally")
-	f.BoolVar(&env.DisabledSecretsForceUpdates, "disable-secrets-forced-updates", false, "Disables forced updates for secret changes only")
+	f.BoolVar(&env.DisabledForcedUpdates, "disable-forced-updates", false, "Disables forced updates completally")
+	f.BoolVar(&env.DisabledSecretsForcedUpdates, "disable-secrets-forced-updates", false, "Disables forced updates for secret changes only")
 
 	f.BoolVar(&env.Loop, "loop", false, "keep landscape in sync forever")
 	f.DurationVar(&env.LoopInterval, "loop-interval", 5*time.Minute, "when running in a loop the interval between invocations")

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -119,7 +119,7 @@ func init() {
 	f.StringVar(&env.HelmHome, "helm-home", helmHome, "Helm home directory")
 	f.StringVar(&env.TillerNamespace, "tiller-namespace", tillerNamespace, "Tiller namespace for Helm")
 	f.Var(&env.DisabledStages, "disable", "Stages to be disabled. Available stages are create/update/delete.")
-	f.BoolVar(&env.DisabledForcedUpdates, "disable-forced-updates", false, "Disables forced updates completelly")
+	f.BoolVar(&env.DisabledForcedUpdates, "disable-forced-updates", false, "Disables forced updates completely")
 	f.BoolVar(&env.DisabledSecretsForcedUpdates, "disable-secrets-forced-updates", false, "Disables forced updates for secret changes only")
 
 	f.BoolVar(&env.Loop, "loop", false, "keep landscape in sync forever")

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -51,7 +51,7 @@ var addCmd = &cobra.Command{
 		}
 		fileState := landscaper.NewFileStateProvider(env.ComponentFiles, secretsReader, env.ChartLoader, env.ReleaseNamePrefix, env.Namespace, env.Environment, env.ConfigurationOverrideFile)
 		helmState := landscaper.NewHelmStateProvider(env.HelmClient(), kubeSecrets, env.ReleaseNamePrefix)
-		executor := landscaper.NewExecutor(env.HelmClient(), env.ChartLoader, kubeSecrets, env.DryRun, env.Wait, int64(env.WaitTimeout/time.Second), env.DisabledStages)
+		executor := landscaper.NewExecutor(env.HelmClient(), env.ChartLoader, kubeSecrets, env.DryRun, env.Wait, int64(env.WaitTimeout/time.Second), env.DisabledStages, env.DisabledForcedUpdates, env.DisabledSecretsForcedUpdates)
 
 		for {
 			desired, err := fileState.Components()

--- a/pkg/landscaper/environment.go
+++ b/pkg/landscaper/environment.go
@@ -23,28 +23,28 @@ var tillerTunnel *kube.Tunnel
 
 // Environment contains all the information about the k8s cluster and local configuration
 type Environment struct {
-	HelmHome                    string        // Helm's home directory
-	DryRun                      bool          // If true, don't modify anything
-	Wait                        bool          // Wait until all resources become ready
-	WaitTimeout                 time.Duration // Wait for helm
-	ChartLoader                 ChartLoader   // ChartLoader loads charts
-	ReleaseNamePrefix           string        // Prepend this string to release names
-	ComponentFiles              []string      // Landscaper component file names
-	LandscapeDir                string        // deprecated: ComponentFiles is leading; LandscapeDir merely fills it
-	Namespace                   string        // Default namespace releases are put into; components can override it though
-	Verbose                     bool          // Reduce log level
-	Context                     string        // Kubernetes context to use
-	Loop                        bool          // Keep looping
-	LoopInterval                time.Duration // Loop every duration
-	TillerNamespace             string        // where to install / use tiller
-	AzureKeyVault               string        // Azure keyvault to use for secrets if provided
-	Environment                 string        // Environment selections
-	ConfigurationOverrideFile   string        // Global configuration overrides file
-	DisabledStages              stringSlice   // stages to disable during landscaper apply
-	DisabledForceUpdates        bool          // Disable forced updates completely, just do normal updates
-	DisabledSecretsForceUpdates bool          // Disable forced updates for Secret changes
-	helmClient                  helm.Interface
-	kubeClient                  internalversion.CoreInterface
+	HelmHome                     string        // Helm's home directory
+	DryRun                       bool          // If true, don't modify anything
+	Wait                         bool          // Wait until all resources become ready
+	WaitTimeout                  time.Duration // Wait for helm
+	ChartLoader                  ChartLoader   // ChartLoader loads charts
+	ReleaseNamePrefix            string        // Prepend this string to release names
+	ComponentFiles               []string      // Landscaper component file names
+	LandscapeDir                 string        // deprecated: ComponentFiles is leading; LandscapeDir merely fills it
+	Namespace                    string        // Default namespace releases are put into; components can override it though
+	Verbose                      bool          // Reduce log level
+	Context                      string        // Kubernetes context to use
+	Loop                         bool          // Keep looping
+	LoopInterval                 time.Duration // Loop every duration
+	TillerNamespace              string        // where to install / use tiller
+	AzureKeyVault                string        // Azure keyvault to use for secrets if provided
+	Environment                  string        // Environment selections
+	ConfigurationOverrideFile    string        // Global configuration overrides file
+	DisabledStages               stringSlice   // stages to disable during landscaper apply
+	DisabledForcedUpdates        bool          // Disable forced updates completely, just do normal updates
+	DisabledSecretsForcedUpdates bool          // Disable forced updates for Secret changes
+	helmClient                   helm.Interface
+	kubeClient                   internalversion.CoreInterface
 }
 
 type stringSlice []string

--- a/pkg/landscaper/environment.go
+++ b/pkg/landscaper/environment.go
@@ -23,26 +23,28 @@ var tillerTunnel *kube.Tunnel
 
 // Environment contains all the information about the k8s cluster and local configuration
 type Environment struct {
-	HelmHome                  string        // Helm's home directory
-	DryRun                    bool          // If true, don't modify anything
-	Wait                      bool          // Wait until all resources become ready
-	WaitTimeout               time.Duration // Wait for helm
-	ChartLoader               ChartLoader   // ChartLoader loads charts
-	ReleaseNamePrefix         string        // Prepend this string to release names
-	ComponentFiles            []string      // Landscaper component file names
-	LandscapeDir              string        // deprecated: ComponentFiles is leading; LandscapeDir merely fills it
-	Namespace                 string        // Default namespace releases are put into; components can override it though
-	Verbose                   bool          // Reduce log level
-	Context                   string        // Kubernetes context to use
-	Loop                      bool          // Keep looping
-	LoopInterval              time.Duration // Loop every duration
-	TillerNamespace           string        // where to install / use tiller
-	AzureKeyVault             string        // Azure keyvault to use for secrets if provided
-	Environment               string        // Environment selections
-	ConfigurationOverrideFile string        // Global configuration overrides file
-	helmClient                helm.Interface
-	kubeClient                internalversion.CoreInterface
-	DisabledStages            stringSlice // stages to disable during landscaper apply
+	HelmHome                    string        // Helm's home directory
+	DryRun                      bool          // If true, don't modify anything
+	Wait                        bool          // Wait until all resources become ready
+	WaitTimeout                 time.Duration // Wait for helm
+	ChartLoader                 ChartLoader   // ChartLoader loads charts
+	ReleaseNamePrefix           string        // Prepend this string to release names
+	ComponentFiles              []string      // Landscaper component file names
+	LandscapeDir                string        // deprecated: ComponentFiles is leading; LandscapeDir merely fills it
+	Namespace                   string        // Default namespace releases are put into; components can override it though
+	Verbose                     bool          // Reduce log level
+	Context                     string        // Kubernetes context to use
+	Loop                        bool          // Keep looping
+	LoopInterval                time.Duration // Loop every duration
+	TillerNamespace             string        // where to install / use tiller
+	AzureKeyVault               string        // Azure keyvault to use for secrets if provided
+	Environment                 string        // Environment selections
+	ConfigurationOverrideFile   string        // Global configuration overrides file
+	DisabledStages              stringSlice   // stages to disable during landscaper apply
+	DisabledForceUpdates        bool          // Disable forced updates completely, just do normal updates
+	DisabledSecretsForceUpdates bool          // Disable forced updates for Secret changes
+	helmClient                  helm.Interface
+	kubeClient                  internalversion.CoreInterface
 }
 
 type stringSlice []string

--- a/pkg/landscaper/executor.go
+++ b/pkg/landscaper/executor.go
@@ -21,25 +21,29 @@ type Executor interface {
 }
 
 type executor struct {
-	helmClient     helm.Interface
-	chartLoader    ChartLoader
-	kubeSecrets    SecretsWriteDeleter
-	dryRun         bool
-	wait           bool
-	waitTimeout    int64
-	disabledStages []string
+	helmClient                   helm.Interface
+	chartLoader                  ChartLoader
+	kubeSecrets                  SecretsWriteDeleter
+	dryRun                       bool
+	wait                         bool
+	waitTimeout                  int64
+	disabledStages               []string
+	disabledForcedUpdates        bool
+	disabledSecretsForcedUpdates bool
 }
 
 // NewExecutor is a factory method to create a new Executor
-func NewExecutor(helmClient helm.Interface, chartLoader ChartLoader, kubeSecrets SecretsWriteDeleter, dryRun bool, wait bool, waitTimeout int64, disabledStages []string) Executor {
+func NewExecutor(helmClient helm.Interface, chartLoader ChartLoader, kubeSecrets SecretsWriteDeleter, dryRun bool, wait bool, waitTimeout int64, disabledStages []string, disabledForcedUpdates bool, disabledSecretsForcedUpdates bool) Executor {
 	return &executor{
-		helmClient:     helmClient,
-		chartLoader:    chartLoader,
-		kubeSecrets:    kubeSecrets,
-		dryRun:         dryRun,
-		wait:           wait,
-		waitTimeout:    waitTimeout,
-		disabledStages: disabledStages,
+		helmClient:                   helmClient,
+		chartLoader:                  chartLoader,
+		kubeSecrets:                  kubeSecrets,
+		dryRun:                       dryRun,
+		wait:                         wait,
+		waitTimeout:                  waitTimeout,
+		disabledStages:               disabledStages,
+		disabledForcedUpdates:        disabledForcedUpdates,
+		disabledSecretsForcedUpdates: disabledSecretsForcedUpdates,
 	}
 }
 

--- a/pkg/landscaper/executor_test.go
+++ b/pkg/landscaper/executor_test.go
@@ -87,7 +87,7 @@ func TestExecutorApply(t *testing.T) {
 		},
 	}
 
-	result, err := NewExecutor(helmMock, chartLoadMock, secretsMock, false, false, waitTimeout, disabledStages).Apply(des, cur)
+	result, err := NewExecutor(helmMock, chartLoadMock, secretsMock, false, false, waitTimeout, disabledStages, false, false).Apply(des, cur)
 	require.NoError(t, err)
 	require.Equal(t, len(result["create"]), 1)
 	require.Equal(t, len(result["update"]), 1)
@@ -146,7 +146,7 @@ func TestExecutorApplyWithForcedUpdatesAndDeleteCreateDisableWhenExistingSecretV
 
 	createDeleteDisabled := []string{"create", "delete"}
 
-	result, err := NewExecutor(helmMock, chartLoadMock, secretsMock, false, false, waitTimeout, createDeleteDisabled).Apply(des, cur)
+	result, err := NewExecutor(helmMock, chartLoadMock, secretsMock, false, false, waitTimeout, createDeleteDisabled, false, false).Apply(des, cur)
 	require.NoError(t, err)
 	require.Equal(t, len(result["create"]), 1)
 	require.Equal(t, len(result["update"]), 0)
@@ -200,7 +200,7 @@ func TestExecutorApplyOptOutForcedUpdatesForSecretChanges(t *testing.T) {
 		},
 	}
 
-	result, err := NewExecutor(helmMock, chartLoadMock, secretsMock, false, false, waitTimeout, []string{}).Apply(des, cur)
+	result, err := NewExecutor(helmMock, chartLoadMock, secretsMock, false, false, waitTimeout, disabledStages, false, true).Apply(des, cur)
 	require.NoError(t, err)
 	require.Equal(t, len(result["create"]), 0)
 	require.Equal(t, len(result["update"]), 1)
@@ -233,7 +233,7 @@ func TestExecutorCreate(t *testing.T) {
 		return nil
 	}}
 
-	err := NewExecutor(helmMock, chartLoadMock, secretsMock, false, false, waitTimeout, disabledStages).CreateComponent(comp)
+	err := NewExecutor(helmMock, chartLoadMock, secretsMock, false, false, waitTimeout, disabledStages, false, false).CreateComponent(comp)
 	require.NoError(t, err)
 }
 
@@ -267,7 +267,7 @@ func TestExecutorUpdate(t *testing.T) {
 		},
 	}
 
-	err := NewExecutor(helmMock, chartLoadMock, secretsMock, false, false, waitTimeout, disabledStages).UpdateComponent(comp)
+	err := NewExecutor(helmMock, chartLoadMock, secretsMock, false, false, waitTimeout, disabledStages, false, false).UpdateComponent(comp)
 	require.NoError(t, err)
 }
 
@@ -293,7 +293,7 @@ func TestExecutorDelete(t *testing.T) {
 		return nil
 	}}
 
-	err := NewExecutor(helmMock, chartLoadMock, secretsMock, false, false, waitTimeout, disabledStages).DeleteComponent(comp)
+	err := NewExecutor(helmMock, chartLoadMock, secretsMock, false, false, waitTimeout, disabledStages, false, false).DeleteComponent(comp)
 	require.NoError(t, err)
 }
 
@@ -373,7 +373,7 @@ func TestExecutorApplyWithDisabledStages(t *testing.T) {
 		},
 	}
 
-	result, err := NewExecutor(helmMock, chartLoadMock, secretsMock, false, false, waitTimeout, []string{"delete", "create", "update"}).Apply(des, cur)
+	result, err := NewExecutor(helmMock, chartLoadMock, secretsMock, false, false, waitTimeout, []string{"delete", "create", "update"}, false, false).Apply(des, cur)
 	require.NoError(t, err)
 	require.Equal(t, len(result["create"]), 0)
 	require.Equal(t, len(result["update"]), 0)

--- a/pkg/landscaper/executor_test.go
+++ b/pkg/landscaper/executor_test.go
@@ -264,8 +264,8 @@ func TestExecutorApplyOptOutForcedUpdatesCompletely(t *testing.T) {
 	require.Equal(t, len(result["create"]), 0)
 	require.Equal(t, len(result["update"]), 2)
 	require.Equal(t, len(result["delete"]), 0)
-	require.Equal(t, result["update"][0], updiff.Name)
-	require.Equal(t, result["update"][1], uptwodiff.Name)
+	require.Contains(t, result["update"], updiff.Name)
+	require.Contains(t, result["update"], uptwodiff.Name)
 }
 
 func TestExecutorCreate(t *testing.T) {


### PR DESCRIPTION
## Use case:

Some of the official helm charts we deploy have secrets generated from their `values.yaml` and every time we run landscaper without changing anything on those deployments or environment variables

The charts that are currently behaving in this way are `stable/logstash` and `stable/rabbitmq`

## Implemented feature:

Opt-out forced updates using the flag `--disable-forced-updates` or only dsiable forced updates for secret changes `--disable-secrets-forced-updates`

