### PR TITLE
Bump golang to v1.13 for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
  - docker
 
 go:
-  - '1.11'
+  - '1.13.x'
 
 go_import_path: github.com/eneco/landscaper
 


### PR DESCRIPTION
[landscaper brew formula ](https://github.com/Homebrew/homebrew-core/pull/47631)is using go 1.13 for building the artifact (which works well), so bump the golang version for Travis.